### PR TITLE
[HOPSWORKS-681] Bugfix: remove extra .cert.pem from ca chain file path (+ add test)

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/PKI.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/PKI.java
@@ -39,6 +39,12 @@
 
 package io.hops.hopsworks.common.security;
 
+import io.hops.hopsworks.common.util.Settings;
+import org.apache.commons.io.FileUtils;
+import org.javatuples.Pair;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -47,13 +53,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-
-import io.hops.hopsworks.common.util.Settings;
-import org.apache.commons.io.FileUtils;
-import org.javatuples.Pair;
-
-import javax.ejb.EJB;
-import javax.ejb.Stateless;
 
 import static io.hops.hopsworks.common.security.PKI.CAType.ROOT;
 
@@ -224,7 +223,7 @@ public class PKI {
   }
 
   public Path getCertPath(CAType caType, String certFileName) {
-    return Paths.get(getCACertsDir(caType).toString(), certFileName + ".cert.pem");
+    return Paths.get(getCACertsDir(caType).toString(), certFileName);
   }
 
   public Path getKeyPath(CAType caType, String keyFileName) {

--- a/hopsworks-ear/test/spec/appservice_spec.rb
+++ b/hopsworks-ear/test/spec/appservice_spec.rb
@@ -1,0 +1,70 @@
+=begin
+ This file is part of Hopsworks
+ Copyright (C) 2018, Logical Clocks AB. All rights reserved
+
+ Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ the GNU Affero General Public License as published by the Free Software Foundation,
+ either version 3 of the License, or (at your option) any later version.
+
+ Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License along with this program.
+ If not, see <https://www.gnu.org/licenses/>.
+=end
+
+describe "On #{ENV['OS']}" do
+  describe 'appservice' do
+    after (:all) {clean_projects}
+
+    describe "#create" do
+
+      context 'without valid keystore and password' do
+        before :all do
+          with_valid_project
+        end
+
+        it "should fail to get Kafka schema" do
+          post "#{ENV['HOPSWORKS_API']}/appservice/schema",
+               {
+                   keyStorePwd: "-",
+                   keyStore: "-",
+                   topicName: "test",
+                   version: 1
+               }
+          expect_json(errorMsg: "Could not authenticate user")
+          expect_status(401)
+        end
+      end
+
+      context 'with keystore and password' do
+        before :all do
+          with_valid_project
+        end
+
+        it "should be authenticated for getting the Kafka schema" do
+          project = get_project
+          download_cert_endpoint = "#{ENV['HOPSWORKS_API']}/project/" + project.id.to_s + "/downloadCert"
+          data = 'password=Pass123'
+          headers = {"Content-Type" => 'application/x-www-form-urlencoded'}
+          post download_cert_endpoint, data, headers # this POST request will trigger a materialization of keystore and pwd to /srv/hops/certs-dir/transient/
+          key_pwd_file_pattern = "/srv/hops/certs-dir/transient/*.key"
+          expect(!Dir.glob(key_pwd_file_pattern).empty?)
+          key_pwd_file = Dir.glob(key_pwd_file_pattern)[0]
+          key_pwd = File.read(key_pwd_file)
+          user_key_cert_pwd= UserCerts.find_by(projectname:project.projectname)
+          json_data = {
+              keyStorePwd: key_pwd,
+              keyStore: Base64.encode64(user_key_cert_pwd.user_key),
+              topicName: "test",
+              version: 1
+          }
+          json_data = json_data.to_json
+          post "#{ENV['HOPSWORKS_API']}/appservice/schema", json_data # This post request authenticates with keystore and pwd to get schema
+          expect_status(200)
+        end
+      end
+    end
+  end
+end

--- a/hopsworks-ear/test/spec/factories/user_certs.rb
+++ b/hopsworks-ear/test/spec/factories/user_certs.rb
@@ -1,0 +1,20 @@
+=begin
+ This file is part of Hopsworks
+ Copyright (C) 2018, Logical Clocks AB. All rights reserved
+
+ Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ the GNU Affero General Public License as published by the Free Software Foundation,
+ either version 3 of the License, or (at your option) any later version.
+
+ Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License along with this program.
+ If not, see <https://www.gnu.org/licenses/>.
+=end
+class UserCerts < ActiveRecord::Base
+  def self.table_name
+    "user_certs"
+  end
+end


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ x] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x ] HOPSWORKS JIRA issue has been opened for this PR
- [ x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-681

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix and new integration test to avoid introducing the same bug in the future

* **What is the new behavior (if this is a feature change)?**
Correctly set the path when reading materialized certificates

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
- remove extra .cert.pem from ca chain file path
- add integration tests for appservice /schema

Tests: https://github.com/logicalclocks/hops-testing/pull/165