### PR TITLE
[HOPSWORKS-688] Remove private key cert from truststore in YARN containers

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -904,7 +904,7 @@ public class CertificateMaterializer {
             
             Path trustStore = new Path(remoteDirectory + Path.SEPARATOR + key.getExtendedUsername()
                 + TRUSTSTORE_SUFFIX);
-            writeToHDFS(dfso, trustStore, material.getKeyStore().array());
+            writeToHDFS(dfso, trustStore, material.getTrustStore().array());
             dfso.setOwner(trustStore, ownerName, groupName);
             dfso.setPermission(trustStore, permissions);
   


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [X] Passes the tests
- [X] HOPSWORKS JIRA issue has been opened for this PR
- [X] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-688

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
Correctly set the truststore in YARN containers to only contain trusted authorities certificates, not private key certificates of clients.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

A test-scenario is described below which explains the effects of this PR.

Example user for this test: `kafkapython__meb10000`

#### Test result **before** PR
1. Start a YARN container, either with jupyter service or jobs service.
2. Go to the container's working directory
3. List contents of the keystore
Go to container working directory and type:
```bash
keytool -list -v -keystore k_certificate
```
enter the password and you get back:
```bash
Keystore type: jks
Keystore provider: SUN

Your keystore contains 2 entries

Alias name: caroot
Creation date: Oct 2, 2018
Entry type: trustedCertEntry

Owner: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
Issuer: CN=HopsRootCA, O=SICS, L=Stockholm, ST=Sweden, C=SE
..
..
..


*******************************************
*******************************************


Alias name: kafkapython__meb10000
Creation date: Oct 2, 2018
Entry type: PrivateKeyEntry
Certificate chain length: 1
Certificate[1]:
Owner: CN=KafkaPython__meb10000, O=hopsworks, L=1234-5678-1234-5678, ST=Stockholm lÃ¤n, C=SE
Issuer: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
..
..
..
```
I.e the keystore contains intermediate CA certificate as well as private key certificate.
4. List contents of the truststore
Go to the container directory and type:
```bash
keytool -list -v -keystore t_certificate
```
and you get back:
```bash
Keystore type: jks
Keystore provider: SUN

Your keystore contains 2 entries

Alias name: caroot
Creation date: Oct 2, 2018
Entry type: trustedCertEntry

Owner: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
Issuer: CN=HopsRootCA, O=SICS, L=Stockholm, ST=Sweden, C=SE
..
..
..


*******************************************
*******************************************


Alias name: kafkapython__meb10000
Creation date: Oct 2, 2018
Entry type: PrivateKeyEntry
Certificate chain length: 1
Certificate[1]:
Owner: CN=KafkaPython__meb10000, O=hopsworks, L=1234-5678-1234-5678, ST=Stockholm lÃ¤n, C=SE
Issuer: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
..
..
..
```
I.e the truststore contains intermediate CA certificate as well as private key certificate. In fact, the keystore and the truststore have the exact same contents.

#### Test result **after** PR
1. Start a YARN container, either with jupyter service or jobs service.
2. Go to the container's working directory
3. List contents of the keystore
Go to container working directory and type:
```bash
keytool -list -v -keystore k_certificate
```
enter the password and you get back:
```bash
Keystore type: jks
Keystore provider: SUN

Your keystore contains 2 entries

Alias name: caroot
Creation date: Oct 2, 2018
Entry type: trustedCertEntry

Owner: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
Issuer: CN=HopsRootCA, O=SICS, L=Stockholm, ST=Sweden, C=SE
..
..
..


*******************************************
*******************************************


Alias name: kafkapython__meb10000
Creation date: Oct 2, 2018
Entry type: PrivateKeyEntry
Certificate chain length: 1
Certificate[1]:
Owner: CN=KafkaPython__meb10000, O=hopsworks, L=1234-5678-1234-5678, ST=Stockholm lÃ¤n, C=SE
Issuer: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
..
..
..
```
I.e the keystore contains intermediate CA certificate as well as private key certificate.
4. List contents of the truststore
Go to the container directory and type:
```bash
keytool -list -v -keystore t_certificate
```
and you get back:
```bash
Keystore type: jks
Keystore provider: SUN

Your keystore contains 1 entry

Alias name: caroot
Creation date: Oct 2, 2018
Entry type: trustedCertEntry

Owner: CN=HopsIntermediateCA, O=SICS, ST=Sweden, C=SE
Issuer: CN=HopsRootCA, O=SICS, L=Stockholm, ST=Sweden, C=SE
..
..
..
```
**I.e after this PR, the truststore contains only the intermediate CA certificate, not the private key certificate that is only stored in the keystore.**