### PR TITLE
[HOPSWORKS-696] filter out control codes from previewfile response

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dataset/FilePreviewDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dataset/FilePreviewDTO.java
@@ -94,7 +94,8 @@ public class FilePreviewDTO {
             + "\", \"extension\":\"" + extension
             + "\", \"content\":\"" + content.replace("\\", "\\\\'").
             replace("\"", "\\\"").replace("\n", "\\n").
-            replace("\r", "\\r").replace("\t", "\\t")
+            replace("\r", "\\r").replace("\t", "\\t").
+            replaceAll("[\\p{Cntrl}]", "")
             + "\"}]}";
   }
 


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [X] HOPSWORKS JIRA issue has been opened for this PR
- [X] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-696

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
Filter out control codes from JSON response returned from previewFile

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
Example use-case when this bug occurs:

You write Kafka messages to HDFS **.txt file** without any decoding, and the messages include control code 4: "end of transmission", which means that you cannot preview the file. 

Moreover the preview does not fail with an exception returned by Hopsworks, the preview fails because of a Javascript error on the frontend. 

After this PR you can previewFiles that contain control codes because those codes are removed before returning the JSON response.

I have tested on a VM that this PR does not affect the image-preview. 