### PR TITLE
[HOPSWORKS-674]  Fine-grain locking for CertificateMaterializer operations

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/CertificateMaterializerAdmin.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/CertificateMaterializerAdmin.java
@@ -102,7 +102,7 @@ public class CertificateMaterializerAdmin {
   public Response getMaterializerState(@Context SecurityContext sc, @Context HttpServletRequest request) {
   
     CertificateMaterializer.MaterializerState<Map<String, Map<String, Integer>>, Map<String, Map<String, Integer>>,
-        Map<String, Set<String>>> materializerState = certificateMaterializer.getState();
+        Map<String, Set<String>>, Map<String, Boolean>> materializerState = certificateMaterializer.getState();
     
     List<MaterializerStateResponse.CryptoMaterial> localStateResponse = createMaterializerResponse(materializerState
         .getLocalMaterial());
@@ -120,7 +120,7 @@ public class CertificateMaterializerAdmin {
     }
     
     MaterializerStateResponse responseState = new MaterializerStateResponse(localStateResponse, remoteStateResponse,
-        fileRemovalsResponse);
+        fileRemovalsResponse, materializerState.getMaterialKeyLocks());
     
     GenericEntity<MaterializerStateResponse> response = new GenericEntity<MaterializerStateResponse>(responseState){};
     return noCacheResponse.getNoCacheResponseBuilder(Response.Status.OK).entity(response).build();

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/dto/MaterializerStateResponse.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/dto/MaterializerStateResponse.java
@@ -42,6 +42,7 @@ package io.hops.hopsworks.api.admin.dto;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 @XmlRootElement
 public class MaterializerStateResponse implements Serializable {
@@ -50,13 +51,15 @@ public class MaterializerStateResponse implements Serializable {
   private List<CryptoMaterial> localMaterializedState;
   private List<CryptoMaterial> remoteMaterializedState;
   private List<CryptoMaterial> scheduledRemovals;
+  private Map<String, Boolean> materialKeyLocks;
   
   public MaterializerStateResponse(
       List<CryptoMaterial> localMaterializedState, List<CryptoMaterial> remoteMaterializedState,
-      List<CryptoMaterial> scheduledRemovals) {
+      List<CryptoMaterial> scheduledRemovals, Map<String, Boolean> materialKeyLocks) {
     this.localMaterializedState = localMaterializedState;
     this.remoteMaterializedState = remoteMaterializedState;
     this.scheduledRemovals = scheduledRemovals;
+    this.materialKeyLocks = materialKeyLocks;
   }
   
   public MaterializerStateResponse() {
@@ -85,6 +88,14 @@ public class MaterializerStateResponse implements Serializable {
   
   public void setScheduledRemovals(List<CryptoMaterial> scheduledRemovals) {
     this.scheduledRemovals = scheduledRemovals;
+  }
+  
+  public Map<String, Boolean> getMaterialKeyLocks() {
+    return materialKeyLocks;
+  }
+  
+  public void setMaterialKeyLocks(Map<String, Boolean> materialKeyLocks) {
+    this.materialKeyLocks = materialKeyLocks;
   }
   
   public static class CryptoMaterial {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -81,10 +81,13 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -110,14 +113,9 @@ public class CertificateMaterializer {
   
   private final Map<MaterialKey, Bag> materializedCerts;
   private final Map<MaterialKey, CryptoMaterial> materialCache;
-  private final Map<MaterialKey, Map<String, Runnable>> fileRemovers;
-  private final ReentrantReadWriteLock localLock;
-  private final ReentrantReadWriteLock.ReadLock localReadLock;
-  private final ReentrantReadWriteLock.WriteLock localWriteLock;
-  private final ReentrantReadWriteLock remoteLock;
-  private final ReentrantReadWriteLock.ReadLock remoteReadLock;
-  private final ReentrantReadWriteLock.WriteLock remoteWriteLock;
+  private final Map<MaterialKey, Map<String, LocalFileRemover>> fileRemovers;
   private final Set<Integer> projectsWithOpenInterpreters;
+  private final Map<MaterialKey, ReentrantReadWriteLock> materialKeyLocks = new ConcurrentHashMap<>();
   
   private String lock_id;
   
@@ -148,12 +146,6 @@ public class CertificateMaterializer {
     materializedCerts = new HashMap<>();
     materialCache = new HashMap<>();
     fileRemovers = new HashMap<>();
-    localLock = new ReentrantReadWriteLock(true);
-    localReadLock = localLock.readLock();
-    localWriteLock = localLock.writeLock();
-    remoteLock = new ReentrantReadWriteLock(true);
-    remoteWriteLock = remoteLock.writeLock();
-    remoteReadLock = remoteLock.readLock();
     projectsWithOpenInterpreters = new ConcurrentSkipListSet<>();
   }
   
@@ -267,12 +259,42 @@ public class CertificateMaterializer {
   public void materializeCertificatesLocal(String userName, String projectName)
       throws IOException {
     MaterialKey key = new MaterialKey(userName, projectName);
+    ReentrantReadWriteLock.WriteLock lock = null;
     try {
-      localWriteLock.lock();
+      lock = getWriteLockForKey(key);
+      lock.lock();
       materializeLocalInternal(key, transientDir);
     } finally {
-      localWriteLock.unlock();
+      lock.unlock();
     }
+  }
+  
+  private ReentrantReadWriteLock.ReadLock getReadLockForKey(MaterialKey key) {
+    ReentrantReadWriteLock lock = getLockForKey(key, false);
+    return lock != null ? lock.readLock() : null;
+  }
+  
+  private ReentrantReadWriteLock.WriteLock getWriteLockForKey(MaterialKey key) {
+    return getLockForKey(key, true).writeLock();
+  }
+  
+  /**
+   * Do NOT use this method directly. Use {@see CertificateMaterializer#getReadLockForKey}
+   * and {@see CertificateMaterializer#getWriteLockForKey} instead.
+   *
+   * @param key Key to take the lock for
+   * @param createIfMissing Create a lock if the key is not already associated with one
+   * @return The lock for that key, or null
+   */
+  private ReentrantReadWriteLock getLockForKey(MaterialKey key, boolean createIfMissing) {
+    if (createIfMissing) {
+      materialKeyLocks.putIfAbsent(key, new ReentrantReadWriteLock(true));
+    }
+    return materialKeyLocks.get(key);
+  }
+  
+  private void removeLockForKey(MaterialKey key) {
+    materialKeyLocks.remove(key);
   }
   
   /**
@@ -301,11 +323,13 @@ public class CertificateMaterializer {
     throws IOException {
     MaterialKey key = new MaterialKey(userName, projectName);
     localDirectory = localDirectory != null ? localDirectory : transientDir;
+    ReentrantReadWriteLock.WriteLock lock = null;
     try {
-      localWriteLock.lock();
+      lock = getWriteLockForKey(key);
+      lock.lock();
       materializeLocalInternal(key, localDirectory);
     } finally {
-      localWriteLock.unlock();
+      lock.unlock();
     }
   }
   
@@ -326,11 +350,17 @@ public class CertificateMaterializer {
    */
   public void removeCertificatesLocal(String userName, String projectName) {
     MaterialKey key = new MaterialKey(userName, projectName);
+    ReentrantReadWriteLock.WriteLock lock = null;
+    boolean materialExist = false;
     try {
-      localWriteLock.lock();
-      removeLocal(key, transientDir);
+      lock = getWriteLockForKey(key);
+      lock.lock();
+      materialExist = removeLocal(key, transientDir);
     } finally {
-      localWriteLock.unlock();
+      if (!materialExist) {
+        removeLockForKey(key);
+      }
+      lock.unlock();
     }
   }
   
@@ -354,11 +384,17 @@ public class CertificateMaterializer {
   public void removeCertificatesLocalCustomDir(String username, String projectName, String localDirectory) {
     MaterialKey key = new MaterialKey(username, projectName);
     localDirectory = localDirectory != null ? localDirectory : transientDir;
+    ReentrantReadWriteLock.WriteLock lock = null;
+    boolean materialExist = false;
     try {
-      localWriteLock.lock();
-      removeLocal(key, localDirectory);
+      lock = getWriteLockForKey(key);
+      lock.lock();
+      materialExist = removeLocal(key, localDirectory);
     } finally {
-      localWriteLock.unlock();
+      if (!materialExist) {
+        removeLockForKey(key);
+      }
+      lock.unlock();
     }
   }
   
@@ -380,11 +416,13 @@ public class CertificateMaterializer {
     }
     remoteDirectory = normalizeURI(remoteDirectory);
     MaterialKey key = new MaterialKey(userName, projectName);
+    ReentrantReadWriteLock.WriteLock lock = null;
     try {
-      remoteWriteLock.lock();
+      lock = getWriteLockForKey(key);
+      lock.lock();
       materializeRemoteInternal(key, ownerName, groupName, permissions, remoteDirectory);
     } finally {
-      remoteWriteLock.unlock();
+      lock.unlock();
     }
   }
   
@@ -401,11 +439,17 @@ public class CertificateMaterializer {
     }
     remoteDirectory = normalizeURI(remoteDirectory);
     MaterialKey key = new MaterialKey(userName, projectName);
+    ReentrantReadWriteLock.WriteLock lock = null;
+    boolean materialExist = false;
     try {
-      remoteWriteLock.lock();
-      removeRemoteInternal(key, remoteDirectory, false);
+      lock = getWriteLockForKey(key);
+      lock.lock();
+      materialExist = removeRemoteInternal(key, remoteDirectory, false);
     } finally {
-      remoteWriteLock.unlock();
+      if (!materialExist) {
+        removeLockForKey(key);
+      }
+      lock.unlock();
     }
   }
   
@@ -425,16 +469,33 @@ public class CertificateMaterializer {
       throw new IllegalArgumentException("Remote directory cannot be null");
     }
     remoteDirectory = normalizeURI(remoteDirectory);
+    MaterialKey key = new MaterialKey(username, projectName);
+    ReentrantReadWriteLock.WriteLock lock = null;
+    boolean deletedMaterial = false;
     try {
-      remoteWriteLock.lock();
-      MaterialKey key = new MaterialKey(username, projectName);
-      removeRemoteInternal(key, remoteDirectory, true);
+      lock = getWriteLockForKey(key);
+      lock.unlock();
+      deletedMaterial = removeRemoteInternal(key, remoteDirectory, true);
       if (bothProjectAndUser) {
+        ReentrantReadWriteLock.WriteLock projectLock = null;
+        boolean deletedProjectMaterial = false;
         key = new MaterialKey(null, projectName);
-        removeRemoteInternal(key, remoteDirectory, true);
+        try {
+          projectLock = getWriteLockForKey(key);
+          projectLock.lock();
+          deletedProjectMaterial = removeRemoteInternal(key, remoteDirectory, true);
+        } finally {
+          if (!deletedProjectMaterial) {
+            removeLockForKey(key);
+          }
+          projectLock.unlock();
+        }
       }
     } finally {
-      remoteWriteLock.unlock();
+      if (!deletedMaterial) {
+        removeLockForKey(key);
+      }
+      lock.unlock();
     }
   }
   
@@ -459,8 +520,14 @@ public class CertificateMaterializer {
    */
   public CryptoMaterial getUserMaterial(String username, String projectName) throws CryptoPasswordNotFoundException {
     MaterialKey key = new MaterialKey(username, projectName);
+    ReentrantReadWriteLock.ReadLock lock = null;
     try {
-      localReadLock.lock();
+      lock = getReadLockForKey(key);
+      if (lock == null) {
+        throw new CryptoPasswordNotFoundException("Could not find a lock associated with this key "
+            + key.getExtendedUsername());
+      }
+      lock.lock();
       CryptoMaterial material = materialCache.get(key);
       if (material == null) {
         throw new CryptoPasswordNotFoundException("Cryptographic material for user <" + key.getExtendedUsername() + "" +
@@ -468,7 +535,9 @@ public class CertificateMaterializer {
       }
       return material;
     } finally {
-      localReadLock.unlock();
+      if (lock != null) {
+        lock.unlock();
+      }
     }
   }
   
@@ -501,8 +570,14 @@ public class CertificateMaterializer {
   public boolean existsInLocalStore(String username, String projectName, String directory) {
     directory = directory != null ? directory : transientDir;
     MaterialKey key = new MaterialKey(username, projectName);
+    ReentrantReadWriteLock.ReadLock lock = null;
     try {
-      localReadLock.lock();
+      lock = getReadLockForKey(key);
+      if (lock == null) {
+        LOG.log(Level.WARNING, "Could not find read lock for key " + key.getExtendedUsername());
+        return false;
+      }
+      lock.lock();
       Bag materializedPaths = materializedCerts.get(key);
       if (materializedPaths == null) {
         return false;
@@ -510,7 +585,9 @@ public class CertificateMaterializer {
       
       return materializedPaths.contains(directory);
     } finally {
-      localReadLock.unlock();
+      if (lock != null) {
+        lock.unlock();
+      }
     }
   }
   
@@ -557,8 +634,9 @@ public class CertificateMaterializer {
    */
   @SuppressWarnings("unchecked")
   public MaterializerState<Map<String, Map<String, Integer>>, Map<String, Map<String, Integer>>,
-      Map<String, Set<String>>> getState() {
-    MaterializerState<Map<MaterialKey, Bag>, List<RemoteMaterialReferences>, Map<MaterialKey, Map<String, Runnable>>>
+      Map<String, Set<String>>, Map<String, Boolean>> getState() {
+    MaterializerState<Map<MaterialKey, Bag>, List<RemoteMaterialReferences>, Map<MaterialKey,
+        Map<String, Runnable>>, Map<MaterialKey, ReentrantReadWriteLock>>
         state = getImmutableState();
     
     Map<MaterialKey, Bag> localMaterialState = state.getLocalMaterial();
@@ -602,42 +680,76 @@ public class CertificateMaterializer {
       simpleScheduledRemovals.put(username, entry.getValue().keySet());
     }
     
-    return new MaterializerState<>(simpleLocalMaterialState, simpleRemoteMaterialState, simpleScheduledRemovals);
+    Map<MaterialKey, ReentrantReadWriteLock> materialKeyLocks = state.getMaterialKeyLocks();
+    // Username, Locked
+    Map<String, Boolean> flatMaterialKeyLocks = new HashMap<>(materialKeyLocks.size());
+    for (Map.Entry<MaterialKey, ReentrantReadWriteLock> lock : materialKeyLocks.entrySet()) {
+      flatMaterialKeyLocks.put(lock.getKey().getExtendedUsername(), lock.getValue().isWriteLocked());
+    }
+    
+    return new MaterializerState<>(simpleLocalMaterialState, simpleRemoteMaterialState,
+        simpleScheduledRemovals, flatMaterialKeyLocks);
   }
   
   private MaterializerState<Map<MaterialKey, Bag>, List<RemoteMaterialReferences>,
-      Map<MaterialKey, Map<String, Runnable>>> getImmutableState() {
+      Map<MaterialKey, Map<String, Runnable>>, Map<MaterialKey, ReentrantReadWriteLock>> getImmutableState() {
     Map<MaterialKey, Bag> localMaterial = null;
     Map<MaterialKey, Map<String, Runnable>> scheduledRemovals = null;
     List<RemoteMaterialReferences> remoteMaterial = null;
+    Map<MaterialKey, ReentrantReadWriteLock> materialKeyLocks = null;
+  
+    // Take all the write locks
+    TreeSet<ReentrantReadWriteLock> acquiredLocks = acquireWriteLocks(materialKeyLocks);
     try {
-      localWriteLock.lock();
       localMaterial = MapUtils.unmodifiableMap(materializedCerts);
       scheduledRemovals = MapUtils.unmodifiableMap(fileRemovers);
-    } finally {
-      localWriteLock.unlock();
-    }
-    
-    try {
-      remoteWriteLock.lock();
+      materialKeyLocks = MapUtils.unmodifiableMap(materialKeyLocks);
       remoteMaterial = remoteMaterialReferencesFacade.findAll();
     } finally {
-      remoteWriteLock.unlock();
+      // Release all locks acquired
+      releaseWriteLocks(acquiredLocks);
     }
     
-    return new MaterializerState(localMaterial, remoteMaterial, scheduledRemovals);
+    return new MaterializerState(localMaterial, remoteMaterial, scheduledRemovals, materialKeyLocks);
   }
   
+  private TreeSet<ReentrantReadWriteLock> acquireWriteLocks(Map<MaterialKey, ReentrantReadWriteLock> lockSet) {
+    TreeSet<ReentrantReadWriteLock> acquiredLocks = new TreeSet<>(new Comparator<ReentrantReadWriteLock>() {
+      @Override
+      public int compare(ReentrantReadWriteLock t0, ReentrantReadWriteLock t1) {
+        if (t0.hashCode() < t1.hashCode()) {
+          return -1;
+        } else if (t0.hashCode() > t1.hashCode()) {
+          return 1;
+        }
+        return 0;
+      }
+    });
+    
+    lockSet.values().stream()
+        .forEach(l -> {
+          l.writeLock().lock();
+          acquiredLocks.add(l);
+        });
+    return acquiredLocks;
+  }
+
+  private void releaseWriteLocks(TreeSet<ReentrantReadWriteLock> acquiredLocks) {
+    Set<ReentrantReadWriteLock> reversedLocks = acquiredLocks.descendingSet();
+    reversedLocks.stream().forEach(l -> l.writeLock().unlock());
+  }
   
-  public class MaterializerState<T, S, R> {
+  public class MaterializerState<T, S, R, P> {
     private final T localMaterial;
     private final S remoteMaterial;
     private final R scheduledRemovals;
+    private final P materialKeyLocks;
     
-    public MaterializerState(T localMaterial, S remoteMaterial, R scheduledRemovals) {
+    public MaterializerState(T localMaterial, S remoteMaterial, R scheduledRemovals, P materialKeyLocks) {
       this.localMaterial = localMaterial;
       this.remoteMaterial = remoteMaterial;
       this.scheduledRemovals = scheduledRemovals;
+      this.materialKeyLocks = materialKeyLocks;
     }
     
     public T getLocalMaterial() {
@@ -650,6 +762,10 @@ public class CertificateMaterializer {
     
     public R getScheduledRemovals() {
       return scheduledRemovals;
+    }
+    
+    public P getMaterialKeyLocks() {
+      return materialKeyLocks;
     }
   }
   
@@ -732,12 +848,12 @@ public class CertificateMaterializer {
   // Return true if materializeCertificates should proceed with the materialization
   private boolean checkWithScheduledRemovalsLocal(MaterialKey key, String materializationDirectory)
       throws IOException {
-    Map<String, Runnable> materialRemovers = fileRemovers.get(key);
+    Map<String, LocalFileRemover> materialRemovers = fileRemovers.get(key);
     if (materialRemovers == null) {
       return true;
     }
     
-    LocalFileRemover localFileRemover = (LocalFileRemover) materialRemovers.get(materializationDirectory);
+    LocalFileRemover localFileRemover = materialRemovers.get(materializationDirectory);
     if (localFileRemover == null) {
       return true;
     }
@@ -792,21 +908,23 @@ public class CertificateMaterializer {
   /*
    * Remove local section
    */
-  private void removeLocal(MaterialKey key, String materializationDirectory) {
+  private boolean removeLocal(MaterialKey key, String materializationDirectory) {
     Bag materialBag = materializedCerts.get(key);
     if (materialBag != null) {
       materialBag.remove(materializationDirectory, 1);
       if (materialBag.getCount(materializationDirectory) <= 0) {
         scheduleFileRemover(key, materializationDirectory);
       }
+      return true;
     }
+    return false;
   }
   
   private void scheduleFileRemover(MaterialKey key, String materializationDirectory) {
     LocalFileRemover fileRemover = new LocalFileRemover(key, materialCache.get(key), materializationDirectory);
     fileRemover.scheduledFuture = scheduler.schedule(fileRemover, DELAY_VALUE, DELAY_TIMEUNIT);
     
-    Map<String, Runnable> materialRemovesForKey = fileRemovers.get(key);
+    Map<String, LocalFileRemover> materialRemovesForKey = fileRemovers.get(key);
     if (materialRemovesForKey != null) {
       materialRemovesForKey.put(materializationDirectory, fileRemover);
     } else {
@@ -831,14 +949,16 @@ public class CertificateMaterializer {
   }
   
   private void forceRemoveLocalMaterial(String username, String projectName, String materializationDirectory) {
+    ReentrantReadWriteLock.WriteLock lock = null;
     try {
-      localWriteLock.lock();
       materializationDirectory = materializationDirectory != null ? materializationDirectory : transientDir;
       MaterialKey key = new MaterialKey(username, projectName);
+      lock = getWriteLockForKey(key);
+      lock.lock();
       // First remove from File Removers list
-      Map<String, Runnable> materialRemovers = fileRemovers.get(key);
+      Map<String, LocalFileRemover> materialRemovers = fileRemovers.get(key);
       if (materialRemovers != null) {
-        LocalFileRemover fileRemover = (LocalFileRemover) materialRemovers.remove(materializationDirectory);
+        LocalFileRemover fileRemover = materialRemovers.remove(materializationDirectory);
         if (fileRemover != null) {
           fileRemover.scheduledFuture.cancel(true);
         }
@@ -862,8 +982,9 @@ public class CertificateMaterializer {
       
       // Then from local FS
       deleteMaterialFromLocalFs(key, materializationDirectory);
+      removeLockForKey(key);
     } finally {
-      localWriteLock.unlock();
+      lock.unlock();
     }
   }
   
@@ -991,7 +1112,7 @@ public class CertificateMaterializer {
    * Remove remote section
    */
   
-  private void removeRemoteInternal(MaterialKey key, String remoteDirectory, boolean force) {
+  private boolean removeRemoteInternal(MaterialKey key, String remoteDirectory, boolean force) {
     RemoteMaterialReferences materialRef = null;
     RemoteMaterialRefID identifier = new RemoteMaterialRefID(key.getExtendedUsername(), remoteDirectory);
     
@@ -1043,12 +1164,15 @@ public class CertificateMaterializer {
         try {
           if (!deletedMaterial) {
             remoteMaterialReferencesFacade.releaseLock(identifier, lock_id);
+          } else {
+            removeLockForKey(key);
           }
         } catch (AcquireLockException ex) {
           LOG.log(Level.SEVERE, "Cannot release lock for " + identifier, ex);
         }
       }
     }
+    return deletedMaterial;
   }
   
   private String normalizeURI(String uri) {
@@ -1227,34 +1351,37 @@ public class CertificateMaterializer {
       this.cryptoMaterial = cryptoMaterial;
       this.materializationDirectory = materializationDirectory != null ? materializationDirectory : transientDir;
     }
-    
+  
     @Override
     public void run() {
-      deleteMaterialFromLocalFs(key, materializationDirectory);
-      Map<String, Runnable> materialRemovers = fileRemovers.get(key);
-      if (materialRemovers != null) {
-        materialRemovers.remove(materializationDirectory);
-        if (materialRemovers.isEmpty()) {
-          fileRemovers.remove(key);
-        }
-  
-        // No more references to that crypto material, wipe out password
-        try {
-          localWriteLock.lock();
+      ReentrantReadWriteLock.WriteLock lock = null;
+      try {
+        lock = getWriteLockForKey(key);
+        lock.lock();
+        deleteMaterialFromLocalFs(key, materializationDirectory);
+        Map<String, LocalFileRemover> materialRemovers = fileRemovers.get(key);
+        if (materialRemovers != null) {
+          materialRemovers.remove(materializationDirectory);
+          if (materialRemovers.isEmpty()) {
+            fileRemovers.remove(key);
+          }
+        
+          // No more references to that crypto material, wipe out password
           Bag materialBag = materializedCerts.get(key);
-          if (materialBag.isEmpty()) {
+          if (materialBag != null && materialBag.isEmpty()) {
             materializedCerts.remove(key);
             CryptoMaterial material = materialCache.remove(key);
             if (material != null) {
               material.wipePassword();
             }
           }
-        } finally {
-          localWriteLock.unlock();
-        }
         
-        LOG.log(Level.FINEST, "Deleted crypto material for <" + key.getExtendedUsername() + "> from directory "
-            + materializationDirectory);
+          LOG.log(Level.FINEST, "Deleted crypto material for <" + key.getExtendedUsername() + "> from directory "
+              + materializationDirectory);
+        }
+        removeLockForKey(key);
+      } finally {
+        lock.unlock();
       }
     }
   }


### PR DESCRIPTION
[HOPSWORKS-674]  Fine-grain locking when materializing keys locally
[HOPSWORKS-674]  Fine-grain locking for remote crypto material operations

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-674

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
Lock per MaterialKey instead of global lock when CertificateMaterializer performs operations

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change

* **Other information**:
