### PR TITLE
[HOPSWORKS-866] Support JobName in the Feature Store API

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/app/ApplicationService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/app/ApplicationService.java
@@ -527,8 +527,8 @@ public class ApplicationService {
         featurestoreController.getFeaturestoreForProjectWithName(project, featurestoreJsonDTO.getFeaturestoreName());
     Featurestore featurestore = featurestoreController.getFeaturestoreWithId(featurestoreDTO.getFeaturestoreId());
     Jobs job = null;
-    if (featurestoreJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, featurestoreJsonDTO.getJobId());
+    if(featurestoreJsonDTO.getJobName() != null && !featurestoreJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, featurestoreJsonDTO.getJobName());
     String featureStr = featurestoreUtil.makeCreateTableColumnsStr(featurestoreJsonDTO.getFeatures());
     try {
       featuregroupController.dropFeaturegroup(featurestoreJsonDTO.getName(),
@@ -587,8 +587,8 @@ public class ApplicationService {
             project, featurestore, featurestoreJsonDTO.getName(),
             featurestoreJsonDTO.getVersion());
     Jobs job = null;
-    if (featurestoreJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, featurestoreJsonDTO.getJobId());
+    if(featurestoreJsonDTO.getJobName() != null && !featurestoreJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, featurestoreJsonDTO.getJobName());
     FeaturegroupDTO updatedFeaturegroupDTO = featuregroupController.updateFeaturegroupMetadata(
         featurestore, featuregroupDTO.getId(), job, featurestoreJsonDTO.getDependencies(),
         featurestoreJsonDTO.getFeatureCorrelationMatrix(), featurestoreJsonDTO.getDescriptiveStatistics(),
@@ -635,8 +635,8 @@ public class ApplicationService {
     Featurestore featurestore = featurestoreController.getFeaturestoreWithId(featurestoreDTO.getFeaturestoreId());
 
     Jobs job = null;
-    if (featurestoreJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, featurestoreJsonDTO.getJobId());
+    if(featurestoreJsonDTO.getJobName() != null && !featurestoreJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, featurestoreJsonDTO.getJobName());
     Dataset trainingDatasetsFolder = featurestoreUtil.getTrainingDatasetFolder(featurestore.getProject());
     String trainingDatasetDirectoryName = featurestoreUtil.getTrainingDatasetPath(
         inodeFacade.getPath(trainingDatasetsFolder.getInode()),
@@ -708,8 +708,8 @@ public class ApplicationService {
         project, featurestore, featurestoreJsonDTO.getName(), featurestoreJsonDTO.getVersion()
     );
     Jobs job = null;
-    if (featurestoreJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, featurestoreJsonDTO.getJobId());
+    if(featurestoreJsonDTO.getJobName() != null && !featurestoreJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, featurestoreJsonDTO.getJobName());
     TrainingDatasetDTO updatedTrainingDataset = trainingDatasetController.updateTrainingDataset(
         featurestore, trainingDatasetDTO.getId(), job, featurestoreJsonDTO.getDependencies(),
         featurestoreJsonDTO.getDataFormat(), featurestoreJsonDTO.getDescription(),

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/FeaturestoreService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/FeaturestoreService.java
@@ -231,8 +231,8 @@ public class FeaturestoreService {
     FeaturestoreDTO featurestoreDTO = featurestoreController.getFeaturestoreForProjectWithId(project, featurestoreId);
     Featurestore featurestore = featurestoreController.getFeaturestoreWithId(featurestoreDTO.getFeaturestoreId());
     Jobs job = null;
-    if (featuregroupJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, featuregroupJsonDTO.getJobId());
+    if (featuregroupJsonDTO.getJobName() != null)
+      job = jobFacade.findByProjectAndName(project, featuregroupJsonDTO.getJobName());
     String featureStr = featurestoreUtil.makeCreateTableColumnsStr(featuregroupJsonDTO.getFeatures());
     try {
       featuregroupController.dropFeaturegroup(featuregroupJsonDTO.getName(),
@@ -559,8 +559,8 @@ public class FeaturestoreService {
     FeaturestoreDTO featurestoreDTO = featurestoreController.getFeaturestoreForProjectWithId(project, featurestoreId);
     Featurestore featurestore = featurestoreController.getFeaturestoreWithId(featurestoreDTO.getFeaturestoreId());
     Jobs job = null;
-    if (featuregroupJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, featuregroupJsonDTO.getJobId());
+    if (featuregroupJsonDTO.getJobName() != null && !featuregroupJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, featuregroupJsonDTO.getJobName());
     FeaturegroupDTO updatedFeaturegroupDTO = featuregroupController.updateFeaturegroupMetadata(
         featurestore, featuregroupId, job, featuregroupJsonDTO.getDependencies(),
         featuregroupJsonDTO.getFeatureCorrelationMatrix(), featuregroupJsonDTO.getDescriptiveStatistics(),
@@ -682,8 +682,8 @@ public class FeaturestoreService {
     FeaturestoreDTO featurestoreDTO = featurestoreController.getFeaturestoreForProjectWithId(project, featurestoreId);
     Featurestore featurestore = featurestoreController.getFeaturestoreWithId(featurestoreDTO.getFeaturestoreId());
     Jobs job = null;
-    if (trainingDatasetJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, trainingDatasetJsonDTO.getJobId());
+    if (trainingDatasetJsonDTO.getJobName() != null && !trainingDatasetJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, trainingDatasetJsonDTO.getJobName());
     Dataset trainingDatasetsFolder = featurestoreUtil.getTrainingDatasetFolder(featurestore.getProject());
     String trainingDatasetDirectoryName = featurestoreUtil.getTrainingDatasetPath(
         inodeFacade.getPath(trainingDatasetsFolder.getInode()),
@@ -813,8 +813,8 @@ public class FeaturestoreService {
     Featurestore featurestore = featurestoreController.getFeaturestoreWithId(featurestoreDTO.getFeaturestoreId());
 
     Jobs job = null;
-    if (trainingDatasetJsonDTO.getJobId() != null)
-      job = jobFacade.findByProjectAndId(project, trainingDatasetJsonDTO.getJobId());
+    if (trainingDatasetJsonDTO.getJobName() != null && !trainingDatasetJsonDTO.getJobName().isEmpty())
+      job = jobFacade.findByProjectAndName(project, trainingDatasetJsonDTO.getJobName());
     TrainingDatasetDTO oldTrainingDatasetDTO =
         trainingDatasetController.getTrainingDatasetWithIdAndFeaturestore(featurestore, trainingdatasetid);
     if (!oldTrainingDatasetDTO.getName().equals(trainingDatasetJsonDTO.getName())) {

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/json/FeaturegroupJsonDTO.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/json/FeaturegroupJsonDTO.java
@@ -32,18 +32,19 @@ import java.util.List;
 public class FeaturegroupJsonDTO extends FeaturestoreEntityJsonDTO {
 
   public FeaturegroupJsonDTO() {
-    super(null, null, null, null, null,
+    super(null, null, null, null,
         null, null, null, null,
-        false, false, null);
+        false, false, null, null);
   }
 
   public FeaturegroupJsonDTO(
-      List<FeatureDTO> features, String featuregroupName, Integer jobId,
+      List<FeatureDTO> features, String featuregroupName,
       String description, List<String> dependencies, Integer version,
       FeatureCorrelationMatrixDTO featureCorrelationMatrix, DescriptiveStatsDTO descriptiveStatistics,
       boolean updateMetadata,
-      boolean updateStats, FeatureDistributionsDTO featuresHistogram, ClusterAnalysisDTO clusterAnalysis) {
-    super(jobId, description, dependencies, version, featuregroupName, featureCorrelationMatrix, descriptiveStatistics,
-        featuresHistogram, clusterAnalysis, updateMetadata, updateStats, features);
+      boolean updateStats, FeatureDistributionsDTO featuresHistogram, ClusterAnalysisDTO clusterAnalysis,
+      String jobName) {
+    super(description, dependencies, version, featuregroupName, featureCorrelationMatrix, descriptiveStatistics,
+        featuresHistogram, clusterAnalysis, updateMetadata, updateStats, features, jobName);
   }
 }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/json/FeaturestoreEntityJsonDTO.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/json/FeaturestoreEntityJsonDTO.java
@@ -33,7 +33,7 @@ import java.util.List;
 @XmlRootElement
 public abstract class FeaturestoreEntityJsonDTO {
 
-  private Integer jobId;
+  private String jobName;
   private String description;
   private List<String> dependencies;
   private Integer version;
@@ -48,11 +48,10 @@ public abstract class FeaturestoreEntityJsonDTO {
 
 
   public FeaturestoreEntityJsonDTO(
-      Integer jobId, String description, List<String> dependencies, Integer version, String name,
+      String description, List<String> dependencies, Integer version, String name,
       FeatureCorrelationMatrixDTO featureCorrelationMatrix, DescriptiveStatsDTO descriptiveStatistics,
       FeatureDistributionsDTO featuresHistogram, ClusterAnalysisDTO clusterAnalysis,
-      boolean updateMetadata, boolean updateStats, List<FeatureDTO> features) {
-    this.jobId = jobId;
+      boolean updateMetadata, boolean updateStats, List<FeatureDTO> features, String jobName) {
     this.description = description;
     this.dependencies = dependencies;
     this.version = version;
@@ -64,11 +63,7 @@ public abstract class FeaturestoreEntityJsonDTO {
     this.updateMetadata = updateMetadata;
     this.updateStats = updateStats;
     this.features = features;
-  }
-
-  @XmlElement
-  public Integer getJobId() {
-    return jobId;
+    this.jobName = jobName;
   }
 
   @XmlElement
@@ -126,8 +121,9 @@ public abstract class FeaturestoreEntityJsonDTO {
     return features;
   }
 
-  public void setJobId(Integer jobId) {
-    this.jobId = jobId;
+  @XmlElement
+  public String getJobName() {
+    return jobName;
   }
 
   public void setDescription(String description) {
@@ -174,10 +170,14 @@ public abstract class FeaturestoreEntityJsonDTO {
     this.features = features;
   }
 
+  public void setJobName(String jobName) {
+    this.jobName = jobName;
+  }
+
   @Override
   public String toString() {
     return "FeaturestoreEntityJsonDTO{" +
-        "jobId=" + jobId +
+        "jobName=" + jobName +
         ", description='" + description + '\'' +
         ", dependencies='" + dependencies + '\'' +
         ", version=" + version +
@@ -189,6 +189,7 @@ public abstract class FeaturestoreEntityJsonDTO {
         ", updateMetadata=" + updateMetadata +
         ", updateStats=" + updateStats +
         ", features=" + features +
+        ", name=" + name +
         '}';
   }
 }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/json/TrainingDatasetJsonDTO.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/json/TrainingDatasetJsonDTO.java
@@ -35,19 +35,19 @@ public class TrainingDatasetJsonDTO extends FeaturestoreEntityJsonDTO{
   private String dataFormat;
 
   public TrainingDatasetJsonDTO() {
-    super(null, null, null, null, null,
+    super(null, null, null, null,
         null, null, null, null,
-        false, false, null);
+        false, false, null, null);
   }
 
   public TrainingDatasetJsonDTO(
-      Integer jobId, String description, List<String> dependencies, Integer version,
+      String description, List<String> dependencies, Integer version,
       String dataFormat, String trainingDatasetName, FeatureCorrelationMatrixDTO featureCorrelationMatrix,
       DescriptiveStatsDTO descriptiveStatistics, FeatureDistributionsDTO featuresHistogram,
       ClusterAnalysisDTO clusterAnalysis, List<FeatureDTO> features,
-      boolean updateMetadata, boolean updateStats) {
-    super(jobId, description, dependencies, version, trainingDatasetName, featureCorrelationMatrix,
-        descriptiveStatistics, featuresHistogram, clusterAnalysis, updateMetadata, updateStats, features);
+      boolean updateMetadata, boolean updateStats, String jobName) {
+    super(description, dependencies, version, trainingDatasetName, featureCorrelationMatrix,
+        descriptiveStatistics, featuresHistogram, clusterAnalysis, updateMetadata, updateStats, features, jobName);
     this.dataFormat = dataFormat;
   }
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/app/FeaturestoreJsonDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/app/FeaturestoreJsonDTO.java
@@ -35,7 +35,7 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
   String name;
   Integer version;
   String description;
-  Integer jobId;
+  String jobName;
   FeatureCorrelationMatrixDTO featureCorrelationMatrix;
   DescriptiveStatsDTO descriptiveStatistics;
   boolean updateMetadata = false;
@@ -52,16 +52,15 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
 
   public FeaturestoreJsonDTO(
       String featurestoreName, String name, Integer version, String description,
-      Integer jobId, List<String> dependencies, List<FeatureDTO> features,
+      List<String> dependencies, List<FeatureDTO> features,
       FeatureCorrelationMatrixDTO featureCorrelationMatrix,
       DescriptiveStatsDTO descriptiveStatistics, boolean updateMetadata, boolean updateStats,
       FeatureDistributionsDTO featuresHistogram,
-      String dataFormat, ClusterAnalysisDTO clusterAnalysis) {
+      String dataFormat, ClusterAnalysisDTO clusterAnalysis, String jobName) {
     this.featurestoreName = featurestoreName;
     this.name = name;
     this.version = version;
     this.description = description;
-    this.jobId = jobId;
     this.dependencies = dependencies;
     this.features = features;
     this.featureCorrelationMatrix = featureCorrelationMatrix;
@@ -71,6 +70,7 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
     this.featuresHistogram = featuresHistogram;
     this.dataFormat = dataFormat;
     this.clusterAnalysis = clusterAnalysis;
+    this.jobName = jobName;
   }
 
   public String getFeaturestoreName() {
@@ -103,14 +103,6 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
 
   public void setDescription(String description) {
     this.description = description;
-  }
-
-  public Integer getJobId() {
-    return jobId;
-  }
-
-  public void setJobId(Integer jobId) {
-    this.jobId = jobId;
   }
 
   public void setFeatures(List<FeatureDTO> features) {
@@ -185,6 +177,13 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
     this.clusterAnalysis = clusterAnalysis;
   }
 
+  public String getJobName() {
+    return jobName;
+  }
+
+  public void setJobName(String jobName) {
+    this.jobName = jobName;
+  }
 
   @Override
   public String toString() {
@@ -193,7 +192,6 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
         ", name='" + name + '\'' +
         ", version=" + version +
         ", description='" + description + '\'' +
-        ", jobId=" + jobId +
         ", featureCorrelationMatrix=" + featureCorrelationMatrix +
         ", descriptiveStatistics=" + descriptiveStatistics +
         ", updateMetadata=" + updateMetadata +
@@ -203,6 +201,7 @@ public class FeaturestoreJsonDTO extends KeystoreDTO {
         ", dataFormat='" + dataFormat + '\'' +
         ", clusterAnalysis=" + clusterAnalysis +
         ", dependencies=" + dependencies +
+        ", jobName=" + jobName +
         '}';
   }
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -321,6 +321,14 @@ public class SparkYarnRunnerBuilder {
       builder.addToAppMasterEnvironment("KAFKA_BROKERS", settings.getKafkaBrokersStr());
     }
 
+    //JobName is used by hops-util
+    builder.addToAppMasterEnvironment("HOPSWORKS_JOB_NAME", jobName);
+    jobHopsworksProps.put(Settings.SPARK_EXECUTORENV_JOB_NAME,
+        new ConfigProperty(
+            Settings.SPARK_EXECUTORENV_JOB_NAME,
+            HopsUtils.IGNORE,
+            jobName));
+
     //Set Spark specific environment variables
     builder.addToAppMasterEnvironment("SPARK_YARN_MODE", "true");
     builder.addToAppMasterEnvironment("SPARK_YARN_STAGING_DIR", stagingPath);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -40,6 +40,7 @@ package io.hops.hopsworks.common.util;
 
 import com.google.common.base.Splitter;
 import io.hops.hopsworks.common.dao.jobs.description.Jobs;
+import io.hops.hopsworks.common.dao.project.Project;
 import io.hops.hopsworks.common.dao.user.UserFacade;
 import io.hops.hopsworks.common.dao.user.Users;
 import io.hops.hopsworks.common.dao.user.security.ua.UserAccountsEmailMessages;
@@ -91,7 +92,6 @@ import java.util.regex.Pattern;
 
 import static io.hops.hopsworks.common.dao.kafka.KafkaFacade.DLIMITER;
 import static io.hops.hopsworks.common.dao.kafka.KafkaFacade.SLASH_SEPARATOR;
-import io.hops.hopsworks.common.dao.project.Project;
 
 @Singleton
 @ConcurrencyManagement(ConcurrencyManagementType.BEAN)
@@ -750,6 +750,7 @@ public class Settings implements Serializable {
   public static final String SPARK_EXECUTORENV_LD_LIBRARY_PATH = "spark.executorEnv.LD_LIBRARY_PATH";
   public static final String SPARK_EXECUTORENV_HDFS_USER = "spark.executorEnv.HDFS_USER";
   public static final String SPARK_EXECUTORENV_HADOOP_USER_NAME = "spark.executorEnv.HADOOP_USER_NAME";
+  public static final String SPARK_EXECUTORENV_JOB_NAME = "spark.executorEnv.JOB_NAME";
   public static final String SPARK_YARN_IS_PYTHON_ENV = "spark.yarn.isPython";
   public static final String SPARK_YARN_SECONDARY_JARS = "spark.yarn.secondary.jars";
 
@@ -1802,7 +1803,7 @@ public class Settings implements Serializable {
   //Glassfish truststore, used by hopsutil to initialize https connection to Hopsworks
   public static final String CRYPTO_MATERIAL_PASSWORD = "material_passwd";
 
-  //Used to retrieve schema by HopsUtil
+  //Used by HopsUtil
   public static final String HOPSWORKS_PROJECTID_PROPERTY = "hopsworks.projectid";
   public static final String HOPSWORKS_PROJECTNAME_PROPERTY = "hopsworks.projectname";
   public static final String HOPSWORKS_PROJECTUSER_PROPERTY = "hopsworks.projectuser";

--- a/hopsworks-ear/test/spec/helpers/featurestore_helper.rb
+++ b/hopsworks-ear/test/spec/helpers/featurestore_helper.rb
@@ -30,7 +30,7 @@ module FeaturestoreHelper
     json_data = {
         name: featuregroup_name,
         dependencies: [],
-        jobId: nil,
+        jobName: nil,
         features: [
             {
                 type: "INT",
@@ -52,7 +52,7 @@ module FeaturestoreHelper
     json_data = {
         name: featuregroup_name,
         dependencies: [],
-        jobId: nil,
+        jobName: nil,
         features: [
             {
                 type: "INT",
@@ -74,7 +74,7 @@ module FeaturestoreHelper
     json_data = {
         name: "",
         dependencies: [],
-        jobId: nil,
+        jobName: nil,
         features: [
         ],
         description: "",
@@ -90,7 +90,7 @@ module FeaturestoreHelper
     json_data = {
         name: "new_dataset_name",
         dependencies: [],
-        jobId: nil,
+        jobName: nil,
         description: "new_testtrainingdatasetdescription",
         version: training_dataset_version,
         dataFormat: "tfrecords"
@@ -106,7 +106,7 @@ module FeaturestoreHelper
     json_data = {
         name: training_dataset_name,
         dependencies: [],
-        jobId: nil,
+        jobName: nil,
         description: "testtrainingdatasetdescription",
         version: 1,
         dataFormat: "tfrecords"
@@ -121,7 +121,7 @@ module FeaturestoreHelper
     json_data = {
         name: training_dataset_name,
         dependencies: [],
-        jobId: nil,
+        jobName: nil,
         description: "testtrainingdatasetdescription2",
         version: version,
         dataFormat: "parquet"

--- a/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
@@ -186,7 +186,7 @@ angular.module('hopsWorksApp')
                 var featuregroupJson = {
                     "name": self.featuregroupName,
                     "dependencies": self.dependencies,
-                    "jobId": $scope.selected.value.id,
+                    "jobName": $scope.selected.value.name,
                     "description": self.featuregroupDoc,
                     "features": self.features,
                     "version": 1,

--- a/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
@@ -188,7 +188,7 @@ angular.module('hopsWorksApp')
                 var featuregroupJson = {
                     "name": self.featuregroupName,
                     "dependencies": self.dependencies,
-                    "jobId": $scope.selected.value.id,
+                    "jobName": $scope.selected.value.name,
                     "description": self.featuregroupDoc,
                     "features": self.features,
                     "version": self.version + 1,

--- a/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
@@ -132,7 +132,7 @@ angular.module('hopsWorksApp')
                 var trainingDatasetJson = {
                     "name": self.trainingDatasetName,
                     "dependencies": self.dependencies,
-                    "jobId": self.job.id,
+                    "jobName": self.job.name,
                     "version": self.trainingDataset.version + 1,
                     "description": self.trainingDatasetDescription,
                     "dataFormat": self.trainingDatasetFormat

--- a/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
@@ -133,7 +133,7 @@ angular.module('hopsWorksApp')
                 var trainingDatasetJson = {
                     "name": self.trainingDatasetName,
                     "dependencies": self.dependencies,
-                    "jobId": $scope.selected.value.id,
+                    "jobName": $scope.selected.value.name,
                     "version": 1,
                     "description": self.trainingDatasetDescription,
                     "dataFormat": self.trainingDatasetFormat,

--- a/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
@@ -201,7 +201,7 @@ angular.module('hopsWorksApp')
                 var featuregroupJson = {
                     "name": self.featuregroupName,
                     "dependencies": self.dependencies,
-                    "jobId": $scope.selected.value.id,
+                    "jobName": $scope.selected.value.name,
                     "description": self.featuregroupDoc,
                     "features": self.features,
                     "version": self.version,

--- a/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
@@ -145,7 +145,7 @@ angular.module('hopsWorksApp')
                 var trainingDatasetJson = {
                     "name": self.trainingDatasetName,
                     "dependencies": self.dependencies,
-                    "jobId": self.job.id,
+                    "jobName": self.job.name,
                     "version": self.trainingDataset.version,
                     "description": self.trainingDatasetDescription,
                     "dataFormat": self.trainingDatasetFormat,


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-853

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

* **What is the new behavior (if this is a feature change)?**
Changes the featurestore API to use jobName instead of JobId. This involves changes to the REST API JSON payload and the util-libraries.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Update the util-libraries 

* **Other information**:
When this PR is merged, these three PRs can be merged as well:

- https://github.com/logicalclocks/hops-examples/pull/28
- https://github.com/logicalclocks/hops-util-py/pull/27
- https://github.com/logicalclocks/hops-util/pull/23