### PR TITLE
[HOPSWORKS-873] Allow overwrite when creating new training datasets

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/app/ApplicationService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/app/ApplicationService.java
@@ -649,9 +649,11 @@ public class ApplicationService {
               -1, true);
     } catch (DatasetException e) {
       if (e.getErrorCode() == RESTCodes.DatasetErrorCode.DATASET_SUBDIR_ALREADY_EXISTS) {
-        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.TRAINING_DATASET_ALREADY_EXISTS, Level.FINE,
-            "The path to create the dataset already exists: " + trainingDatasetDirectoryName +
-                ", delete the directory and try again.", e.getMessage(), e);
+        dsUpdateOperations.deleteDatasetFile(project, user, trainingDatasetDirectoryName);
+        fullPath =
+            dsUpdateOperations.createDirectoryInDataset(project, user, trainingDatasetDirectoryName,
+                featurestoreJsonDTO.getDescription(),
+                -1, true);
       } else {
         throw e;
       }

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/FeaturestoreService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/FeaturestoreService.java
@@ -696,9 +696,11 @@ public class FeaturestoreService {
               -1, true);
     } catch (DatasetException e) {
       if (e.getErrorCode() == RESTCodes.DatasetErrorCode.DATASET_SUBDIR_ALREADY_EXISTS) {
-        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.TRAINING_DATASET_ALREADY_EXISTS, Level.FINE,
-            "The path to create the dataset already exists: " + trainingDatasetDirectoryName +
-                ", delete the directory and try again.", e.getMessage(), e);
+        dsUpdateOperations.deleteDatasetFile(project, user, trainingDatasetDirectoryName);
+        fullPath =
+            dsUpdateOperations.createDirectoryInDataset(project, user, trainingDatasetDirectoryName,
+                trainingDatasetJsonDTO.getDescription(),
+                -1, true);
       } else {
         throw e;
       }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-873?filter=-1

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
API semantic change

* **What is the new behavior (if this is a feature change)?**
When creating new training datasets if there already exists a training dataset with the same name, it will get overwritten instead of throwing an error.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
