### PR TITLE
[HOPSWORKS-878] Bugfix: Moving files in Hopsworks datasets browser does not work

### DIFF
--- a/hopsworks-web/yo/app/scripts/services/ModalService.js
+++ b/hopsworks-web/yo/app/scripts/services/ModalService.js
@@ -573,7 +573,7 @@ angular.module('hopsWorksApp')
                 });
                 return modalInstance.result;
             },
-            selectDir: function (size, regex, errorMsg) {
+            selectDir: function (size, regex, errorMsg, dirAllowed) {
                 var modalInstance = $uibModal.open({
                     templateUrl: 'views/selectDir.html',
                     controller: 'SelectFileCtrl as selectFileCtrl',
@@ -595,6 +595,9 @@ angular.module('hopsWorksApp')
                         },
                         errorMsg: function () {
                             return errorMsg;
+                        },
+                        dirAllowed: function () {
+                            return dirAllowed;
                         }
                     }
                 });
@@ -627,7 +630,7 @@ angular.module('hopsWorksApp')
                 });
                 return modalInstance.result;
             },
-            selectLocalFile: function (size, regex, errorMsg) {
+            selectLocalFile: function (size, regex, errorMsg, dirAllowed) {
                 var modalInstance = $uibModal.open({
                     templateUrl: 'views/selectLocalFile.html',
                     controller: 'SelectFileCtrl as selectFileCtrl',
@@ -649,12 +652,15 @@ angular.module('hopsWorksApp')
                         },
                         errorMsg: function () {
                             return errorMsg;
+                        },
+                        dirAllowed: function () {
+                            return dirAllowed;
                         }
                     }
                 });
                 return modalInstance.result;
             },
-            selectLocalDir: function (size, regex, errorMsg) {
+            selectLocalDir: function (size, regex, errorMsg, dirAllowed) {
                 var modalInstance = $uibModal.open({
                     templateUrl: 'views/selectLocalDir.html',
                     controller: 'SelectFileCtrl as selectFileCtrl',
@@ -676,6 +682,9 @@ angular.module('hopsWorksApp')
                         },
                         errorMsg: function () {
                             return errorMsg;
+                        },
+                        dirAllowed: function () {
+                            return dirAllowed;
                         }
                     }
                 });


### PR DESCRIPTION
- Add missing provider to the selectFileCtrl

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/projects/HOPSWORKS/issues/HOPSWORKS-878?filter=allopenissues

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
