### PR TITLE
[HOPSWORKS-887]  Add flag for throwing error when trying to download a file.

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/DataSetService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/project/DataSetService.java
@@ -987,6 +987,9 @@ public class DataSetService {
   @JWTRequired(acceptedTokens={Audience.API}, allowedUserRoles={"HOPS_ADMIN", "HOPS_USER"})
   public Response checkFileForDownload(@PathParam("path") String path,
           @Context SecurityContext sc) throws DatasetException, ProjectException {
+    if(!settings.isDownloadAllowed()){
+      throw new DatasetException(RESTCodes.DatasetErrorCode.DOWNLOAD_NOT_ALLOWED, Level.FINEST);
+    }
     Users user = jWTHelper.getUserPrincipal(sc);
     DsPath dsPath = pathValidator.validatePath(this.project, path);
     Project owningProject = datasetController.getOwningProject(dsPath.getDs());

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/util/DownloadService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/util/DownloadService.java
@@ -54,6 +54,7 @@ import io.hops.hopsworks.common.exception.RESTCodes;
 import io.hops.hopsworks.common.hdfs.DistributedFileSystemOps;
 import io.hops.hopsworks.common.hdfs.DistributedFsService;
 import io.hops.hopsworks.common.hdfs.HdfsUsersController;
+import io.hops.hopsworks.common.util.Settings;
 import io.hops.hopsworks.jwt.exception.SigningKeyNotFoundException;
 import io.hops.hopsworks.jwt.exception.VerificationException;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -92,6 +93,8 @@ public class DownloadService {
   private HdfsUsersController hdfsUsersBean;
   @EJB
   private JWTHelper jWTHelper;
+  @EJB
+  private Settings settings;
 
   private Project project;
 
@@ -107,6 +110,9 @@ public class DownloadService {
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   public Response downloadFromHDFS(@PathParam("path") String path, @QueryParam("token") String token)
     throws DatasetException, ProjectException, SigningKeyNotFoundException, VerificationException {
+    if(!settings.isDownloadAllowed()){
+      throw new DatasetException(RESTCodes.DatasetErrorCode.DOWNLOAD_NOT_ALLOWED, Level.FINEST);
+    }
     DsPath dsPath = pathValidator.validatePath(project, path);
     String fullPath = dsPath.getFullPath().toString();
     DecodedJWT djwt = jWTHelper.verifyOneTimeToken(token, fullPath);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/exception/RESTCodes.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/exception/RESTCodes.java
@@ -294,7 +294,9 @@ public class RESTCodes {
     COPY_FROM_PROJECT(45, "Cannot copy file/folder from another project", Response.Status.FORBIDDEN),
     COPY_TO_PUBLIC_DS(46, "Can not copy to a public dataset.", Response.Status.FORBIDDEN),
     DATASET_SUBDIR_ALREADY_EXISTS(47, "A sub-directory with the same name already exists.",
-        Response.Status.BAD_REQUEST);
+        Response.Status.BAD_REQUEST),
+    DOWNLOAD_NOT_ALLOWED(48, "Downloading files is not allowed. Please contact the system administrator for further " +
+      "information.", Response.Status.FORBIDDEN);
 
 
     private Integer code;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -231,7 +231,8 @@ public class Settings implements Serializable {
   private static final String VARIABLE_ANACONDA_DIR = "anaconda_dir";
   private static final String VARIABLE_ANACONDA_ENABLED = "anaconda_enabled";
   private static final String VARIABLE_ANACONDA_DEFAULT_REPO = "conda_default_repo";
-
+  
+  private static final String VARIABLE_DOWNLOAD_ALLOWED = "download_allowed";
   private static final String VARIABLE_SUPPORT_EMAIL_ADDR = "support_email_addr";
   private static final String VARIABLE_HOPSUTIL_VERSION = "hopsutil_version";
   private static final String VARIABLE_HOPSEXAMPLES_VERSION = "hopsexamples_version";
@@ -529,6 +530,7 @@ public class Settings implements Serializable {
       ANACONDA_DEFAULT_REPO = setStrVar(VARIABLE_ANACONDA_DEFAULT_REPO, ANACONDA_DEFAULT_REPO);
       ANACONDA_ENABLED = Boolean.parseBoolean(setStrVar(
           VARIABLE_ANACONDA_ENABLED, ANACONDA_ENABLED.toString()));
+      DOWNLOAD_ALLOWED = Boolean.parseBoolean(setStrVar(VARIABLE_DOWNLOAD_ALLOWED, DOWNLOAD_ALLOWED.toString()));
       INFLUXDB_IP = setStrVar(VARIABLE_INFLUXDB_IP, INFLUXDB_IP);
       INFLUXDB_PORT = setStrVar(VARIABLE_INFLUXDB_PORT, INFLUXDB_PORT);
       INFLUXDB_USER = setStrVar(VARIABLE_INFLUXDB_USER, INFLUXDB_USER);
@@ -1641,7 +1643,13 @@ public class Settings implements Serializable {
     checkCache();
     return ANACONDA_ENABLED;
   }
-
+  
+  private Boolean DOWNLOAD_ALLOWED = true;
+  public synchronized Boolean isDownloadAllowed() {
+    checkCache();
+    return DOWNLOAD_ALLOWED;
+  }
+  
 //  private String CONDA_CHANNEL_URL = "https://repo.continuum.io/pkgs/free/linux-64/";
   private String CONDA_CHANNEL_URL = "default";
 

--- a/hopsworks-ear/test/spec/dataset_spec.rb
+++ b/hopsworks-ear/test/spec/dataset_spec.rb
@@ -578,6 +578,19 @@ describe "On #{ENV['OS']}" do
           get "#{ENV['HOPSWORKS_API']}/project/#{@project[:id]}/dataset/fileDownload/Resources/README.md?token=" + token 
           expect_status(401)
         end
+        it 'should fail to download a file if variable download_allowed is false' do
+          get "#{ENV['HOPSWORKS_API']}/project/#{@project[:id]}/dataset/checkFileForDownload/Logs/README.md"
+          expect_status(200)
+          token = json_body[:data][:value]
+          setVar("download_allowed", 'false')
+          get "#{ENV['HOPSWORKS_API']}/project/#{@project[:id]}/dataset/checkFileForDownload/Logs/README.md"
+          expect_status(403)
+          get "#{ENV['HOPSWORKS_API']}/project/#{@project[:id]}/dataset/fileDownload/Logs/README.md?token=" + token
+          expect_status(403)
+          #set var back to true
+          setVar("download_allowed", "true")
+          expect(getVar("download_allowed").value). to eq "true"
+        end
       end 
     end
   end

--- a/hopsworks-ear/test/spec/helpers/variables_helper.rb
+++ b/hopsworks-ear/test/spec/helpers/variables_helper.rb
@@ -70,4 +70,17 @@ module VariablesHelper
     variables
   end
 
+  def getVar (id)
+    variables = Variables.find_by(id: id)
+    variables
+  end
+
+  def setVar (id, value)
+    variables = Variables.find_by(id: id)
+    variables.value = value
+    variables.save
+    refresh_variables
+    variables
+  end
+
 end

--- a/hopsworks-web/yo/app/scripts/controllers/datasetsCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/datasetsCtrl.js
@@ -1040,7 +1040,8 @@ angular.module('hopsWorksApp')
                                     var token = success.data.data.value; 
                                     closeToast();
                                     dataSetService.fileDownload(filePath, token);
-                                  }, function (error) {
+                                  },function (error) {
+                                    closeToast();
                                     growl.error(error.data.errorMsg, {title: 'Error', ttl: 5000});
                           });
                         }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
[HOPSWORKS-887](https://logicalclocks.atlassian.net/projects/HOPSWORKS/issues/HOPSWORKS-887)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
There is a new settings variable to enable/disable users from downloading files from within datasets. Be default they are allowed. 

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
https://github.com/logicalclocks/hops-testing/pull/273