### PR TITLE
[HOPSWORKS-929] Don't allow hyphen in featuregroup names

### DIFF
--- a/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
@@ -102,7 +102,8 @@ angular.module('hopsWorksApp')
                     self.featuresDocWrongValue[i] = 1
                 }
 
-                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256) {
+                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256 ||
+                    self.featuregroupName.includes("-")) {
                     self.featuregroupNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {
@@ -128,7 +129,8 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.features.length; i++) {
                     featureNames.push(self.features[i].name)
-                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767) {
+                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767
+                        || self.features[i].name.includes("-")) {
                         self.featuresNameWrongValue[i] = -1
                         self.wrong_values = -1;
                     }

--- a/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
@@ -35,7 +35,7 @@ angular.module('hopsWorksApp')
             self.featuregroupNames = [];
             $scope.selected = {value: self.jobs[0]}
             self.features = []
-            self.hiveRegexp = /^[a-zA-Z0-9-_]+$/;
+            self.hiveRegexp = /^[a-zA-Z0-9_]+$/;
 
             self.featuregroupNameWrongValue = 1;
             self.featuregroupDocWrongValue = 1;
@@ -102,8 +102,7 @@ angular.module('hopsWorksApp')
                     self.featuresDocWrongValue[i] = 1
                 }
 
-                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256 ||
-                    self.featuregroupName.includes("-")) {
+                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256) {
                     self.featuregroupNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {
@@ -129,8 +128,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.features.length; i++) {
                     featureNames.push(self.features[i].name)
-                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767
-                        || self.features[i].name.includes("-")) {
+                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767) {
                         self.featuresNameWrongValue[i] = -1
                         self.wrong_values = -1;
                     }

--- a/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
@@ -143,7 +143,8 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.features.length; i++) {
                     featureNames.push(self.features[i].name)
-                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767) {
+                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767
+                        || self.features[i].name.includes("-")) {
                         self.featuresNameWrongValue[i] = -1
                         self.wrong_values = -1;
                     }

--- a/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
@@ -39,7 +39,7 @@ angular.module('hopsWorksApp')
             self.featuregroups = featuregroups;
             $scope.selected = {value: self.jobs[0]}
             self.features = featuregroup.features;
-            self.hiveRegexp = /^[a-zA-Z0-9-_]+$/;
+            self.hiveRegexp = /^[a-zA-Z0-9_]+$/;
 
             self.featuregroupNameWrongValue = 1;
             self.featuregroupDocWrongValue = 1;
@@ -143,8 +143,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.features.length; i++) {
                     featureNames.push(self.features[i].name)
-                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767
-                        || self.features[i].name.includes("-")) {
+                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767) {
                         self.featuresNameWrongValue[i] = -1
                         self.wrong_values = -1;
                     }

--- a/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
@@ -35,7 +35,7 @@ angular.module('hopsWorksApp')
             self.trainingDatasets = trainingDatasets
             self.trainingDataset=trainingDataset
             self.trainingDatasetId = trainingDataset.id
-            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9-_]+$/;
+            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9_]+$/;
 
             self.trainingDatasetNameWrongValue = 1
             self.trainingDatasetNameNotUnique = 1
@@ -91,8 +91,7 @@ angular.module('hopsWorksApp')
                         self.dependenciesWrongValue[i] = 1
                     }
                 }
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256
-                    || self.trainingDatasetName.includes("-")) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
@@ -91,7 +91,8 @@ angular.module('hopsWorksApp')
                         self.dependenciesWrongValue[i] = 1
                     }
                 }
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256
+                    || self.trainingDatasetName.includes("-")) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
@@ -84,7 +84,8 @@ angular.module('hopsWorksApp')
                         self.dependenciesWrongValue[i] = 1
                     }
                 }
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256
+                    || self.trainingDatasetName.includes("-")) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
@@ -35,7 +35,7 @@ angular.module('hopsWorksApp')
             self.trainingDatasets = trainingDatasets
             $scope.selected = {value: self.jobs[0]}
 
-            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9-_]+$/;
+            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9_]+$/;
 
             self.trainingDatasetNameWrongValue = 1
             self.trainingDatasetNameNotUnique = 1
@@ -84,8 +84,7 @@ angular.module('hopsWorksApp')
                         self.dependenciesWrongValue[i] = 1
                     }
                 }
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256
-                    || self.trainingDatasetName.includes("-")) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
@@ -49,7 +49,7 @@ angular.module('hopsWorksApp')
             }
             $scope.selected = {value: selectedJob}
             self.features = featuregroup.features;
-            self.hiveRegexp = /^[a-zA-Z0-9-_]+$/;
+            self.hiveRegexp = /^[a-zA-Z0-9_]+$/;
 
             self.featuregroupNameWrongValue = 1;
             self.featuregroupDocWrongValue = 1;
@@ -118,8 +118,7 @@ angular.module('hopsWorksApp')
                     self.featuresDocWrongValue[i] = 1
                 }
 
-                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256
-                    || self.featuregroupName.includes("-")) {
+                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256) {
                     self.featuregroupNameWrongValue = -1;
                     self.wrong_values = -1;
                 }
@@ -151,8 +150,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.features.length; i++) {
                     featureNames.push(self.features[i].name)
-                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767
-                        || self.features[i].name.includes("-")) {
+                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767) {
                         self.featuresNameWrongValue[i] = -1
                         self.wrong_values = -1;
                     }

--- a/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
@@ -118,7 +118,8 @@ angular.module('hopsWorksApp')
                     self.featuresDocWrongValue[i] = 1
                 }
 
-                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256) {
+                if (!self.featuregroupName || self.featuregroupName.search(self.hiveRegexp) == -1 || self.featuregroupName.length > 256
+                    || self.featuregroupName.includes("-")) {
                     self.featuregroupNameWrongValue = -1;
                     self.wrong_values = -1;
                 }
@@ -150,7 +151,8 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.features.length; i++) {
                     featureNames.push(self.features[i].name)
-                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767) {
+                    if (self.features[i].name === "" || self.features[i].name.search(self.hiveRegexp) == -1 || self.features[i].name.length > 767
+                        || self.features[i].name.includes("-")) {
                         self.featuresNameWrongValue[i] = -1
                         self.wrong_values = -1;
                     }

--- a/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
@@ -100,7 +100,8 @@ angular.module('hopsWorksApp')
                         self.dependenciesWrongValue[i] = 1
                     }
                 }
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256
+                    || self.trainingDatasetName.includes("-")) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
@@ -35,7 +35,7 @@ angular.module('hopsWorksApp')
             self.trainingDatasets = trainingDatasets
             self.trainingDataset = trainingDataset
             self.trainingDatasetId = trainingDataset.id
-            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9-_]+$/;
+            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9_]+$/;
 
             self.trainingDatasetNameWrongValue = 1
             self.trainingDatasetNameNotUnique = 1
@@ -100,8 +100,7 @@ angular.module('hopsWorksApp')
                         self.dependenciesWrongValue[i] = 1
                     }
                 }
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256
-                    || self.trainingDatasetName.includes("-")) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1 || self.trainingDatasetName.length > 256) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.wrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/views/createFeaturegroup.html
+++ b/hopsworks-web/yo/app/views/createFeaturegroup.html
@@ -39,7 +39,8 @@
             </div>
         </div>
         <div ng-if="createFeaturegroupCtrl.featuregroupNameWrongValue === -1" style="color: red">{{"Feature Group
-            Name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters"}}
+            Name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters.
+            Hyphens are now allowed in the name."}}
         </div>
     </div>
     <div class="view-info">
@@ -164,7 +165,8 @@
                 </div>
             </div>
             <div ng-if="createFeaturegroupCtrl.featuresNameWrongValue[$index] === -1" style="color: red">{{"Feature
-                Name shouldn't be empty and can only contain alphanumeric characters and underscores and max length 767 characters"}}
+                Name shouldn't be empty and can only contain alphanumeric characters and underscores and max length 767 characters.
+                Hyphens are not allowed in the feature name."}}
             </div>
         </div>
         <div class="view-info">

--- a/hopsworks-web/yo/app/views/createFeaturegroup.html
+++ b/hopsworks-web/yo/app/views/createFeaturegroup.html
@@ -40,7 +40,7 @@
         </div>
         <div ng-if="createFeaturegroupCtrl.featuregroupNameWrongValue === -1" style="color: red">{{"Feature Group
             Name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters.
-            Hyphens are now allowed in the name."}}
+            Hyphens are not allowed in the name."}}
         </div>
     </div>
     <div class="view-info">

--- a/hopsworks-web/yo/app/views/createNewFeaturegroupVersion.html
+++ b/hopsworks-web/yo/app/views/createNewFeaturegroupVersion.html
@@ -39,7 +39,8 @@
             </div>
         </div>
         <div ng-if="createNewFeaturegroupVersionCtrl.featuregroupNameWrongValue === -1" style="color: red">{{"Feature Group
-            Name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters"}}
+            Name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters.
+            Hyphens are not allowed in the name."}}
         </div>
     </div>
     <div class="view-info">
@@ -157,7 +158,8 @@
                 </div>
             </div>
             <div ng-if="createNewFeaturegroupVersionCtrl.featuresNameWrongValue[$index] === -1" style="color: red">{{"Feature
-                Name shouldn't be empty and can only contain alphanumeric characters and underscores and max length 767 characters"}}
+                Name shouldn't be empty and can only contain alphanumeric characters and underscores and max length 767 characters.
+                Hyphens are not allowed in the name."}}
             </div>
         </div>
         <div class="view-info">

--- a/hopsworks-web/yo/app/views/createNewTrainingDatasetVersion.html
+++ b/hopsworks-web/yo/app/views/createNewTrainingDatasetVersion.html
@@ -39,7 +39,8 @@
             </div>
         </div>
         <div ng-if="createNewTrainingDatasetVersionCtrl.trainingDatasetNameWrongValue === -1" style="color: red">{{"Training dataset
-            name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters"}}
+            name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters.
+            Hyphens are not allowed in the name."}}
         </div>
     </div>
     <div class="view-info">

--- a/hopsworks-web/yo/app/views/createTrainingDataset.html
+++ b/hopsworks-web/yo/app/views/createTrainingDataset.html
@@ -39,7 +39,8 @@
             </div>
         </div>
         <div ng-if="createTrainingDatasetCtrl.trainingDatasetNameWrongValue === -1" style="color: red">{{"Training dataset
-            name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters"}}
+            name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256 characters.
+            Hyphens are not allowed in the training dataset name."}}
         </div>
     </div>
     <div class="view-info">

--- a/hopsworks-web/yo/app/views/updateFeaturegroup.html
+++ b/hopsworks-web/yo/app/views/updateFeaturegroup.html
@@ -41,7 +41,7 @@
         </div>
         <div ng-if="updateFeaturegroupCtrl.featuregroupNameWrongValue === -1" style="color: red">{{"Feature Group
             Name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256
-            characters"}}
+            characters. Hyphens are not allowed in the name."}}
         </div>
     </div>
     <div class="view-info">
@@ -164,7 +164,7 @@
             </div>
             <div ng-if="updateFeaturegroupCtrl.featuresNameWrongValue[$index] === -1" style="color: red">{{"Feature
                 Name shouldn't be empty and can only contain alphanumeric characters and underscores and max length 767
-                characters"}}
+                characters. Hyphens are not allowed in the name."}}
             </div>
         </div>
         <div class="view-info">

--- a/hopsworks-web/yo/app/views/updateTrainingDataset.html
+++ b/hopsworks-web/yo/app/views/updateTrainingDataset.html
@@ -40,7 +40,7 @@
         <div ng-if="updateTrainingDatasetCtrl.trainingDatasetNameWrongValue === -1" style="color: red">{{"Training
             dataset
             name shouldn't be empty and can only contain alphanumeric characters and underscores, maximum length is 256
-            characters"}}
+            characters. Hyphens are not allowed in the name."}}
         </div>
     </div>
     <div class="view-info">


### PR DESCRIPTION
- Add validation checks for hyphens as Hive do not deal with them very well.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**

https://logicalclocks.atlassian.net/projects/HOPSWORKS/issues/HOPSWORKS-929

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**
Hyphens are not allowed in featuregroups or training dataset names to avoid errors in Hive.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
