### PR TITLE
[HOPSWORKS-852] Add support for petastorm in feature store

### DIFF
--- a/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createFeaturegroupCtrl.js
@@ -35,8 +35,7 @@ angular.module('hopsWorksApp')
             self.featuregroupNames = [];
             $scope.selected = {value: self.jobs[0]}
             self.features = []
-            self.hiveRegexp = /^[a-zA-Z0-9_]+$/;
-
+            self.hiveRegexp = FeaturestoreService.hiveRegExp();
             self.featuregroupNameWrongValue = 1;
             self.featuregroupDocWrongValue = 1;
             self.featuresNameWrongValue = [];

--- a/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewFeaturegroupVersionCtrl.js
@@ -39,8 +39,7 @@ angular.module('hopsWorksApp')
             self.featuregroups = featuregroups;
             $scope.selected = {value: self.jobs[0]}
             self.features = featuregroup.features;
-            self.hiveRegexp = /^[a-zA-Z0-9_]+$/;
-
+            self.hiveRegexp = FeaturestoreService.hiveRegExp();
             self.featuregroupNameWrongValue = 1;
             self.featuregroupDocWrongValue = 1;
             self.featuresNameWrongValue = [];

--- a/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createNewTrainingDatasetVersionCtrl.js
@@ -35,8 +35,7 @@ angular.module('hopsWorksApp')
             self.trainingDatasets = trainingDatasets
             self.trainingDataset=trainingDataset
             self.trainingDatasetId = trainingDataset.id
-            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9_]+$/;
-
+            self.trainingDatasetNameRegexp = FeaturestoreService.trainingDatasetRegExp();
             self.trainingDatasetNameWrongValue = 1
             self.trainingDatasetNameNotUnique = 1
             self.trainingDatasetDescriptionWrongValue = 1;
@@ -44,9 +43,7 @@ angular.module('hopsWorksApp')
             self.wrong_values = 1;
             self.dependenciesNotUnique = 1
             self.working = false;
-            self.dataFormats = [
-                "csv", "tfrecords", "parquet", "tsv", "hdf5", "npy", "orc", "avro", "image"
-            ]
+            self.dataFormats = FeaturestoreService.dataFormats()
             self.trainingDatasetName = trainingDataset.name
             self.trainingDatasetDescription = trainingDataset.description
             self.dependencies = []

--- a/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/createTrainingDatasetCtrl.js
@@ -34,9 +34,7 @@ angular.module('hopsWorksApp')
             self.jobs = self.jobs.concat(jobs);
             self.trainingDatasets = trainingDatasets
             $scope.selected = {value: self.jobs[0]}
-
-            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9_]+$/;
-
+            self.trainingDatasetNameRegexp = FeaturestoreService.trainingDatasetRegExp();
             self.trainingDatasetNameWrongValue = 1
             self.trainingDatasetNameNotUnique = 1
             self.trainingDatasetDescriptionWrongValue = 1;
@@ -54,9 +52,7 @@ angular.module('hopsWorksApp')
             }
             self.trainingDatasetFormat;
 
-            self.dataFormats = [
-                "csv", "tfrecords", "parquet", "tsv", "hdf5", "npy", "orc", "avro", "image"
-            ]
+            self.dataFormats = FeaturestoreService.dataFormats()
             var i;
             self.trainingDatasetNames = []
             for (i = 0; i < self.trainingDatasets.length; i++) {

--- a/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateFeaturegroupCtrl.js
@@ -49,8 +49,7 @@ angular.module('hopsWorksApp')
             }
             $scope.selected = {value: selectedJob}
             self.features = featuregroup.features;
-            self.hiveRegexp = /^[a-zA-Z0-9_]+$/;
-
+            self.hiveRegexp = FeaturestoreService.hiveRegExp();
             self.featuregroupNameWrongValue = 1;
             self.featuregroupDocWrongValue = 1;
             self.featuresNameWrongValue = [];

--- a/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/updateTrainingDatasetCtrl.js
@@ -35,8 +35,7 @@ angular.module('hopsWorksApp')
             self.trainingDatasets = trainingDatasets
             self.trainingDataset = trainingDataset
             self.trainingDatasetId = trainingDataset.id
-            self.trainingDatasetNameRegexp = /^[a-zA-Z0-9_]+$/;
-
+            self.trainingDatasetNameRegexp = FeaturestoreService.trainingDatasetRegExp();
             self.trainingDatasetNameWrongValue = 1
             self.trainingDatasetNameNotUnique = 1
             self.trainingDatasetDescriptionWrongValue = 1;
@@ -44,9 +43,7 @@ angular.module('hopsWorksApp')
             self.wrong_values = 1;
             self.working = false;
             self.dependenciesNotUnique = 1
-            self.dataFormats = [
-                "csv", "tfrecords", "parquet", "tsv", "hdf5", "npy", "orc", "avro", "image"
-            ]
+            self.dataFormats = FeaturestoreService.dataFormats()
             self.trainingDatasetName = trainingDataset.name
             self.trainingDatasetDescription = trainingDataset.description
             self.dependencies = []

--- a/hopsworks-web/yo/app/scripts/services/FeaturestoreService.js
+++ b/hopsworks-web/yo/app/scripts/services/FeaturestoreService.js
@@ -23,6 +23,34 @@ angular.module('hopsWorksApp')
             return {
 
                 /**
+                 * Utility function that returns the supported data formats in the feature store
+                 * @returns list of supported data formats for training datasets
+                 */
+                dataFormats: function() {
+                    return [
+                        "csv", "tfrecords", "parquet", "tsv", "hdf5", "npy", "orc", "avro", "image", "petastorm"
+                    ]
+                },
+
+                /**
+                 * Utility function that returns the regexp for training dataset names
+                 *
+                 * @returns {RegExp} for training datasets
+                 */
+                trainingDatasetRegExp: function() {
+                    return /^[a-zA-Z0-9_]+$/
+                },
+
+                /**
+                 * Utility function that returns the regexp hive table and column names
+                 *
+                 * @returns {RegExp} for hive
+                 */
+                hiveRegExp: function() {
+                    return /^[a-zA-Z0-9_]+$/;
+                },
+
+                /**
                  * Sends a POST request to the backend for creating a feature group
                  *
                  * @param projectId project where the featuregroup will be created


### PR DESCRIPTION
- Allow to specify "petastorm" as data format in the metadata of training datasets

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-852

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the new behavior (if this is a feature change)?**
users can specify petastorm in the metadata of their training datasets

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
