### PR TITLE
[HOPSWORKS-905]  Force remove remove material when we delete a project

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/factories/remote_material_references.rb
+++ b/hopsworks-IT/src/test/ruby/spec/factories/remote_material_references.rb
@@ -1,0 +1,22 @@
+=begin
+ This file is part of Hopsworks
+ Copyright (C) 2019, Logical Clocks AB. All rights reserved
+
+ Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ the GNU Affero General Public License as published by the Free Software Foundation,
+ either version 3 of the License, or (at your option) any later version.
+
+ Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License along with this program.
+ If not, see <https://www.gnu.org/licenses/>.
+=end
+
+class RemoteMaterialReferences < ActiveRecord::Base
+    def self.table_name
+      "remote_material_references"
+    end
+  end
+  

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/security/CertificateMaterializer.java
@@ -456,7 +456,7 @@ public class CertificateMaterializer {
     boolean deletedMaterial = false;
     try {
       lock = getWriteLockForKey(key);
-      lock.unlock();
+      lock.lock();
       deletedMaterial = removeRemoteInternal(key, remoteDirectory, true);
       if (bothProjectAndUser) {
         ReentrantReadWriteLock.WriteLock projectLock = null;


### PR DESCRIPTION
[HOPSWORKS-905]  Remove all project member's certificates from the materializer and add test

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-905

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement

* **What is the new behavior (if this is a feature change)?**
When we delete a project, delete any reference (local or remote) from the certificate materializer. Individual micro-services should have done this, but do it as a safe-guard.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
