### PR TITLE
[HOPSWORKS-715] Append bugfix

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
@@ -220,8 +220,6 @@ public class JupyterConfigFilesGenerator {
       extraJavaOptions.putAll(sparkConfigurationUtil.setJVMProperties(project, sparkJobConfiguration,
         settings, hdfsUser));
 
-      extraJavaOptions.put(Settings.HOPSWORKS_JOBTYPE_PROPERTY, "jupyter");
-
       StringBuilder extraJavaOptionsSb = new StringBuilder();
       for (String key : extraJavaOptions.keySet()) {
         extraJavaOptionsSb.append(" -D").append(key).append("=").append(extraJavaOptions.get(key));

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkYarnRunnerBuilder.java
@@ -183,8 +183,6 @@ public class SparkYarnRunnerBuilder {
     extraJavaOptions.put(Settings.LOGSTASH_JOB_INFO,
             project.getName().toLowerCase() + "," + jobName + "," + job.getId() + ","
                     + YarnRunner.APPID_PLACEHOLDER);
-    extraJavaOptions.put(Settings.HOPSWORKS_JOBTYPE_PROPERTY, jobType.getName().toLowerCase());
-
     //Set up command
     StringBuilder amargs = new StringBuilder("--class ");
     amargs.append(((SparkJobConfiguration) job.getJobConfig()).

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
@@ -134,6 +134,7 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
     addToSparkEnvironment(sparkProps,"HOPSWORKS_USER", usersFullName, settings);
     addToSparkEnvironment(sparkProps,
       Settings.SPARK_PYSPARK_PYTHON, settings.getAnacondaProjectDir(project) + "/bin/python", settings);
+    addToSparkEnvironment(sparkProps, "HOPSWORKS_PROJECT_ID", Integer.toString(project.getId()), settings);
     //If DynamicExecutors are not enabled, set the user defined number
     //of executors
 
@@ -467,6 +468,7 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
     extraJavaOptions.put(Settings.SPARK_JAVA_LIBRARY_PROP, settings.getHadoopSymbolicLinkDir() + "/lib/native/");
     extraJavaOptions.put(Settings.HOPSWORKS_PROJECTUSER_PROPERTY, hdfsUser);
     extraJavaOptions.put(Settings.KAFKA_BROKERADDR_PROPERTY, settings.getKafkaBrokersStr());
+    extraJavaOptions.put(Settings.HOPSWORKS_JOBTYPE_PROPERTY, JobType.SPARK.name());
     if(jobConfiguration.getAppName() != null) {
       extraJavaOptions.put(Settings.HOPSWORKS_JOBNAME_PROPERTY, jobConfiguration.getAppName());
     }


### PR DESCRIPTION
- Add missing spark environment variable that hops-util and hops-util-py depends on

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-715

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix bug that was introduced with rebase of HOPSWORKS-715. Reintroduce the environment variables added here that was removed in the rebase (https://github.com/SirOibaf/hopsworks/pull/3/files).

* **What is the new behavior (if this is a feature change)?**
Add HOPSWORKS_PROJECT_ID to environment for jobs and jupyter

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
Tested with FeaturestoreTourPython, FeaturestoreTourScala, and FeaturestoreTourJob