### PR TITLE
[HOPSWORKS-1060] fix tensorflow and torch lib conflict

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
@@ -120,7 +120,8 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
     addToSparkEnvironment(sparkProps, "HADOOP_USER_NAME", hdfsUser, settings);
     addToSparkEnvironment(sparkProps, "LD_LIBRARY_PATH", settings.getJavaHome() +
       "/jre/lib/amd64/server" + File.pathSeparator + tfLdLibraryPath +
-      settings.getHadoopSymbolicLinkDir() + "/lib/native", settings);
+      settings.getHadoopSymbolicLinkDir() + "/lib/native" + File.pathSeparator + settings.getAnacondaProjectDir(project)
+        + "/lib/", settings);
     if(!Strings.isNullOrEmpty(sparkJobConfiguration.getAppName())) {
       addToSparkEnvironment(sparkProps, "HOPSWORKS_JOB_NAME", sparkJobConfiguration.getAppName(), settings);
     }


### PR DESCRIPTION
- add conda env libs to LD_LIBRARY_PATH to resolve missing dependencies of torch when tensorflow defaults to other libs.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1060

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix for python/torch in the same notebook

* **What is the new behavior (if this is a feature change)?**
torch and tensorflow can now co-exist without lib conflicts

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
