### PR TITLE
[HOPSWORKS-1071] spark.executor.instances should default to spark.dynamicAllocation.minExecutors for Spark Dynamic configurations

### DIFF
--- a/hopsworks-web/yo/app/views/sparkConfig.html
+++ b/hopsworks-web/yo/app/views/sparkConfig.html
@@ -220,8 +220,7 @@
                         <div class="text-right col-md-4">Initial executors <i class="fa fa-info-circle"
                                                                               uib-tooltip="The initial number of Spark executors that should be requested. Must be greater than the minimum and smaller than the maximum number of executors." style="margin-left: 10px"></i></div>
 
-                        <div class="col-md-2 jupyter-left"><input type="number"
-                                                                  ng-change="sparkConfigCtrl.setInitExecs()" min="0" ng-model="sparkConfigCtrl.jobConfig['spark.dynamicAllocation.minExecutors']"
+                        <div class="col-md-2 jupyter-left"><input type="number" min="0" ng-model="sparkConfigCtrl.jobConfig['spark.dynamicAllocation.initialExecutors']"
                                                                   class="form-control">
                         </div>
                     </div>


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
