### PR TITLE
[HOPSWORKS-1164] Refactor Jupyter code to support non-localhost implementations

### DIFF
--- a/hopsworks-admin/src/main/webapp/WEB-INF/beans.xml
+++ b/hopsworks-admin/src/main/webapp/WEB-INF/beans.xml
@@ -38,20 +38,13 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   -->
 
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee 
-                       http://xmlns.jcp.org/xml/ns/javaee/beans_1_2.xsd"
-       version="1.2" bean-discovery-mode="annotated">
-  <!-- Don't allow jee7 to scan for classes from guice or jclouds -->
-  <!--See bug here: https://blogs.oracle.com/theaquarium/entry/default_cdi_enablement_in_java -->
-  <scan>
-    <exclude name="com.sun.jersey.guice.**" />
-    <exclude name="org.jclouds.**" />
-    <exclude name="com.google.inject.**" />     
-    <exclude name="org.sonatype.guice.plexus.shim.PseudoPlexusContainer" />     
-    <exclude name="org.sonatype.guice.plexus.converters.PlexusXmlBeanConverter" />     
-    <exclude name="org.sonatype.guice.**" />    
-  </scan>
-
+<beans
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+    bean-discovery-mode="annotated">
+  <alternatives>
+    <stereotype>io.hops.hopsworks.common.integrations.LocalhostStereotype</stereotype>
+  </alternatives>
 </beans>

--- a/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
+++ b/hopsworks-api/src/main/java/com/predic8/membrane/servlet/embedded/MembraneServlet.java
@@ -15,17 +15,18 @@
  */
 package com.predic8.membrane.servlet.embedded;
 
-import java.io.IOException;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.predic8.membrane.core.Router;
 import com.predic8.membrane.core.rules.ServiceProxy;
 import com.predic8.membrane.core.rules.ServiceProxyKey;
 import io.hops.hopsworks.common.util.Ip;
+import io.hops.hopsworks.common.util.Settings;
+
+import javax.ejb.EJB;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,6 +40,10 @@ public class MembraneServlet extends HttpServlet {
   private static final long serialVersionUID = 1L;
   private static final Logger LOGGER = Logger.getLogger(MembraneServlet.class.getName());
 
+  @EJB
+  Settings settings;
+
+  private String jupyterHost;
 
   /*
    * For websockets, the following paths are used by JupyterHub:
@@ -55,12 +60,20 @@ public class MembraneServlet extends HttpServlet {
    */
 
   @Override
+  public void init() throws ServletException {
+    super.init();
+    jupyterHost = settings.getJupyterHost();
+  }
+
+  @Override
   protected void service(HttpServletRequest req, HttpServletResponse resp)
           throws ServletException, IOException {
 
     String externalIp = Ip.getHost(req.getRequestURL().toString());
 
-    StringBuilder urlBuf = new StringBuilder("http://localhost:");
+    StringBuilder urlBuf = new StringBuilder("http://");
+    urlBuf.append(jupyterHost);
+    urlBuf.append(":");
 
     String pathInfo = req.getPathInfo();
     int endPort = pathInfo.indexOf('/', 1);
@@ -86,7 +99,7 @@ public class MembraneServlet extends HttpServlet {
     }
 
     ServiceProxy sp = new ServiceProxy(
-        new ServiceProxyKey(externalIp, "*", "*", -1), "localhost", targetPort);
+        new ServiceProxyKey(externalIp, "*", "*", -1), jupyterHost, targetPort);
     sp.setTargetURL(urlBuf.toString());
 
     try {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterManager.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterManager.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.dao.jupyter.config;
+
+import io.hops.hopsworks.common.dao.jupyter.JupyterProject;
+import io.hops.hopsworks.common.dao.jupyter.JupyterSettings;
+import io.hops.hopsworks.common.dao.project.Project;
+import io.hops.hopsworks.common.dao.user.Users;
+import io.hops.hopsworks.common.util.OSProcessExecutor;
+import io.hops.hopsworks.common.util.ProcessDescriptor;
+import io.hops.hopsworks.common.util.ProcessResult;
+import io.hops.hopsworks.common.util.Settings;
+import io.hops.hopsworks.exceptions.ServiceException;
+import io.hops.hopsworks.restutils.RESTCodes;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public interface JupyterManager {
+  JupyterDTO startJupyterServer(Project project, String secretConfig, String hdfsUser, Users user,
+    JupyterSettings js, String allowOrigin) throws ServiceException;
+  
+  @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+  default String getJupyterHome(Settings settings, String hdfsUser, Project project, String secret)
+      throws ServiceException {
+    
+    if (project == null || secret == null) {
+      throw new ServiceException(RESTCodes.ServiceErrorCode.JUPYTER_HOME_ERROR, Level.WARNING, "user: " + hdfsUser);
+    }
+    return settings.getJupyterDir() + File.separator
+      + Settings.DIR_ROOT + File.separator + project.getName()
+      + File.separator + hdfsUser + File.separator + secret;
+  }
+
+  @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+  default void projectCleanup(Settings settings, Logger logger, OSProcessExecutor osProcessExecutor, Project project) {
+    String prog = settings.getHopsworksDomainDir() + "/bin/jupyter-project-cleanup.sh";
+    int exitValue;
+    ProcessDescriptor.Builder pdBuilder = new ProcessDescriptor.Builder()
+        .addCommand("/usr/bin/sudo")
+        .addCommand(prog)
+        .addCommand(project.getName());
+    if (!logger.isLoggable(Level.FINE)) {
+      pdBuilder.ignoreOutErrStreams(true);
+    }
+
+    try {
+      ProcessResult processResult = osProcessExecutor.execute(pdBuilder.build());
+      logger.log(Level.FINE, processResult.getStdout());
+      exitValue = processResult.getExitCode();
+    } catch (IOException ex) {
+      logger.log(Level.SEVERE, "Problem cleaning up project: "
+          + project.getName() + ": {0}", ex.toString());
+      exitValue = -2;
+    }
+
+    if (exitValue != 0) {
+      logger.log(Level.WARNING, "Problem remove project's jupyter folder: "
+          + project.getName());
+    }
+  }
+
+  void waitForStartup(Project project, Users user) throws TimeoutException;
+
+  void stopOrphanedJupyterServer(Long pid, Integer port) throws ServiceException;
+  
+  void stopJupyterServer(Project project, Users user, String hdfsUsername, String jupyterHomePath, Long pid,
+      Integer port) throws ServiceException;
+
+  void projectCleanup(Project project);
+  
+  boolean pingServerJupyterUser(JupyterProject jupyterProject);
+  
+  List<JupyterProject> getAllNotebooks();
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterProcessMgr.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterProcessMgr.java
@@ -44,38 +44,34 @@ import io.hops.hopsworks.common.dao.hdfsUser.HdfsUsersFacade;
 import io.hops.hopsworks.common.dao.jupyter.JupyterProject;
 import io.hops.hopsworks.common.dao.jupyter.JupyterSettings;
 import io.hops.hopsworks.common.dao.project.Project;
-import io.hops.hopsworks.restutils.RESTCodes;
-import io.hops.hopsworks.exceptions.ServiceException;
+import io.hops.hopsworks.common.dao.user.Users;
+import io.hops.hopsworks.common.integrations.LocalhostStereotype;
+import io.hops.hopsworks.common.jupyter.TokenGenerator;
 import io.hops.hopsworks.common.util.OSProcessExecutor;
 import io.hops.hopsworks.common.util.ProcessDescriptor;
 import io.hops.hopsworks.common.util.ProcessResult;
 import io.hops.hopsworks.common.util.Settings;
+import io.hops.hopsworks.exceptions.ServiceException;
+import io.hops.hopsworks.restutils.RESTCodes;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.ejb.ConcurrencyManagement;
-import javax.ejb.ConcurrencyManagementType;
-import javax.ejb.DependsOn;
 import javax.ejb.EJB;
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * *
@@ -84,12 +80,12 @@ import java.util.regex.Pattern;
  * The bash script has several commands with parameters that can be exceuted.
  * This class provides a Java interface for executing the commands.
  */
-@Singleton
-@ConcurrencyManagement(ConcurrencyManagementType.CONTAINER)
-@DependsOn("Settings")
-public class JupyterProcessMgr {
+@Stateless
+@LocalhostStereotype
+public class JupyterProcessMgr implements JupyterManager {
 
   private static final Logger LOGGER = Logger.getLogger(JupyterProcessMgr.class.getName());
+  private static final int TOKEN_LENGTH = 48;
 
   @EJB
   private Settings settings;
@@ -113,28 +109,28 @@ public class JupyterProcessMgr {
   public void preDestroy() {
   }
   
+  @Override
   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-  public JupyterDTO startServerAsJupyterUser(Project project, String secretConfig, String hdfsUser, String realName,
-      JupyterSettings js, String allowOrigin) throws ServiceException {
+  public JupyterDTO startJupyterServer(Project project, String secretConfig, String hdfsUser, Users user,
+    JupyterSettings js, String allowOrigin) throws ServiceException {
     
     String prog = settings.getHopsworksDomainDir() + "/bin/jupyter.sh";
     
     Integer port = ThreadLocalRandom.current().nextInt(40000, 59999);
+    String realName = user.getFname() + " " + user.getLname();
     JupyterPaths jp = jupyterConfigFilesGenerator.generateConfiguration(project, secretConfig, hdfsUser, realName,
         hdfsLeFacade.getRPCEndpoint(), js, port, allowOrigin);
     String secretDir = settings.getStagingDir() + Settings.PRIVATE_DIRS + js.getSecret();
-    String logfile = jp.getLogDirPath() + "/" + hdfsUser + "-" + port + ".log";
-    
-    String token = null;
+
+    String token = TokenGenerator.generateToken(TOKEN_LENGTH);
     Long pid = 0l;
     
     // The Jupyter Notebook is running at: http://localhost:8888/?token=c8de56fa4deed24899803e93c227592aef6538f93025fe01
-    boolean foundToken = false;
     int maxTries = 5;
-    
+
     // kill any running servers for this user, clear cached entries
-    while (!foundToken && maxTries > 0) {
-      
+    while (maxTries > 0) {
+
       // use pidfile to kill any running servers
       ProcessDescriptor processDescriptor = new ProcessDescriptor.Builder()
           .addCommand("/usr/bin/sudo")
@@ -149,12 +145,13 @@ public class JupyterProcessMgr {
           .addCommand(secretDir)
           .addCommand(jp.getCertificatesDir())
           .addCommand(hdfsUser)
+          .addCommand(token)
           .redirectErrorStream(true)
           .setCurrentWorkingDirectory(new File(jp.getNotebookPath()))
           .setWaitTimeout(20L, TimeUnit.SECONDS)
           .build();
-      
-      
+
+
       String pidfile = jp.getRunDirPath() + "/jupyter.pid";
       try {
         ProcessResult processResult = osProcessExecutor.execute(processDescriptor);
@@ -164,61 +161,36 @@ public class JupyterProcessMgr {
           LOGGER.log(Level.SEVERE, errorMsg);
           throw new IOException(errorMsg);
         }
-        // The logfile should now contain the token we need to read and save.
-        final BufferedReader br = new BufferedReader(new InputStreamReader(
-            new FileInputStream(logfile), Charset.forName("UTF8")));
-        String line;
-        // [I 11:59:16.597 NotebookApp] The Jupyter Notebook is running at:
-        // http://localhost:8888/?token=c8de56fa4deed24899803e93c227592aef6538f93025fe01
-        String pattern = "(.*)token=(.*)";
-        Pattern r = Pattern.compile(pattern);
-        
-        int linesRead = 0;
-        while (((line = br.readLine()) != null) && !foundToken && linesRead
-            < 10000) {
-          LOGGER.info(line);
-          linesRead++;
-          Matcher m = r.matcher(line);
-          if (m.find()) {
-            token = m.group(2);
-            foundToken = true;
-          }
-        }
-        br.close();
-        
         // Read the pid for Jupyter Notebook
         String pidContents = com.google.common.io.Files.readFirstLine(
             new File(pidfile), Charset.defaultCharset());
         pid = Long.parseLong(pidContents);
-        
+
+        return new JupyterDTO(port, token, pid, secretConfig, jp.getCertificatesDir());
       } catch (Exception ex) {
         LOGGER.log(Level.SEVERE, "Problem executing shell script to start Jupyter server", ex);
         maxTries--;
       }
     }
-    
-    if (!foundToken) {
-      String errorMsg = "Could not read Jupyter token";
-      throw new ServiceException(RESTCodes.ServiceErrorCode.JUPYTER_START_ERROR, Level.SEVERE, errorMsg,
-          errorMsg + " for project " + project);
-    }
-    
-    return new JupyterDTO(port, token, pid, secretConfig, jp.getCertificatesDir());
+
+    String errorMsg = "Failed to start Jupyter";
+    throw new ServiceException(RESTCodes.ServiceErrorCode.JUPYTER_START_ERROR, Level.SEVERE, errorMsg,
+      errorMsg + " for project " + project);
   }
 
-  @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-  public String getJupyterHome(String hdfsUser, Project project, String secret) throws ServiceException {
-    if (project == null || secret == null) {
-      throw new ServiceException(RESTCodes.ServiceErrorCode.JUPYTER_HOME_ERROR, Level.WARNING, "user: " + hdfsUser);
-    }
-    return settings.getJupyterDir() + File.separator
-        + Settings.DIR_ROOT + File.separator + project.getName()
-        + File.separator + hdfsUser + File.separator + secret;
+  @Override
+  public void waitForStartup(Project project, Users user) throws TimeoutException {
+    // Nothing to do as the start is blocking
   }
-  
+
+  public void stopOrphanedJupyterServer(Long pid, Integer port) throws ServiceException {
+    stopJupyterServer(null, null, "Orphaned", "", pid, port);
+  }
+
+  @Override
   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-  public void killServerJupyterUser(String hdfsUsername, String jupyterHomePath, Long pid, Integer port)
-    throws ServiceException {
+  public void stopJupyterServer(Project project, Users user, String hdfsUsername, String jupyterHomePath, Long pid,
+      Integer port) throws ServiceException {
     if (jupyterHomePath == null || pid == null || port == null) {
       throw new IllegalArgumentException("Invalid arguments when stopping the Jupyter Server.");
     }
@@ -265,40 +237,20 @@ public class JupyterProcessMgr {
 
   }
 
+  @Override
   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
   public void projectCleanup(Project project) {
-    String prog = settings.getHopsworksDomainDir() + "/bin/jupyter-project-cleanup.sh";
-    int exitValue;
-    ProcessDescriptor.Builder pdBuilder = new ProcessDescriptor.Builder()
-        .addCommand("/usr/bin/sudo")
-        .addCommand(prog)
-        .addCommand(project.getName());
-    if (!LOGGER.isLoggable(Level.FINE)) {
-      pdBuilder.ignoreOutErrStreams(true);
-    }
-
-    try {
-      ProcessResult processResult = osProcessExecutor.execute(pdBuilder.build());
-      LOGGER.log(Level.FINE, processResult.getStdout());
-      exitValue = processResult.getExitCode();
-    } catch (IOException ex) {
-      LOGGER.log(Level.SEVERE, "Problem cleaning up project: "
-          + project.getName() + ": {0}", ex.toString());
-      exitValue = -2;
-    }
-
-    if (exitValue != 0) {
-      LOGGER.log(Level.WARNING, "Problem remove project's jupyter folder: "
-          + project.getName());
-    }
+    projectCleanup(settings, LOGGER, osProcessExecutor, project);
   }
 
+  @Override
   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
-  public boolean pingServerJupyterUser(Long pid) {
-    int exitValue = executeJupyterCommand("ping", pid.toString());
+  public boolean pingServerJupyterUser(JupyterProject jupyterProject) {
+    int exitValue = executeJupyterCommand("ping", String.valueOf(jupyterProject.getPid()));
     return exitValue == 0;
   }
 
+  @Override
   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
   public List<JupyterProject> getAllNotebooks() {
     List<JupyterProject> allNotebooks = jupyterFacade.getAllNotebookServers();

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/JupyterJWT.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/JupyterJWT.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.jupyter;
+
+import io.hops.hopsworks.common.dao.project.Project;
+import io.hops.hopsworks.common.dao.user.Users;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+public final class JupyterJWT {
+  public final Project project;
+  public final Users user;
+  public final PidAndPort pidAndPort;
+  public final LocalDateTime expiration;
+  public Path tokenFile;
+  public String token;
+  
+  public JupyterJWT(JupyterJWT jupyterJWT) {
+    this(jupyterJWT.project, jupyterJWT.user, jupyterJWT.pidAndPort, jupyterJWT.expiration);
+    this.tokenFile = jupyterJWT.tokenFile;
+  }
+  
+  public JupyterJWT(Project project, Users user, PidAndPort pidAndPort, LocalDateTime expiration) {
+    this.project = project;
+    this.user = user;
+    this.pidAndPort = pidAndPort;
+    this.expiration = expiration;
+  }
+  
+  public boolean maybeRenew(LocalDateTime now) {
+    return now.isAfter(expiration) || now.isEqual(expiration);
+  }
+  
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + project.getId();
+    result = 31 * result + user.getUid();
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o instanceof JupyterJWT) {
+      JupyterJWT other = (JupyterJWT) o;
+      return user.getUid().equals(other.user.getUid()) && project.getId().equals(other.project.getId());
+    }
+    return false;
+  }
+  
+  @Override
+  public String toString() {
+    return "(" + project.getName() + "/" + user.getUsername() + ")";
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/JupyterJWTTokenWriter.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/JupyterJWTTokenWriter.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.jupyter;
+
+import com.google.common.collect.ImmutableSet;
+import io.hops.hopsworks.common.util.Settings;
+import org.apache.commons.io.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.util.Set;
+
+public interface JupyterJWTTokenWriter {
+  
+  Set<PosixFilePermission> TOKEN_FILE_PERMISSIONS = ImmutableSet.of(
+    PosixFilePermission.OWNER_READ,
+    PosixFilePermission.OWNER_WRITE,
+    PosixFilePermission.OWNER_EXECUTE,
+    PosixFilePermission.GROUP_READ,
+    PosixFilePermission.GROUP_WRITE,
+    PosixFilePermission.GROUP_EXECUTE);
+  
+  default void writeToken(Settings settings, JupyterJWT jupyterJWT) throws IOException {
+    FileUtils.writeStringToFile(jupyterJWT.tokenFile.toFile(), jupyterJWT.token);
+    
+    String groupName = settings.getJupyterGroup();
+    UserPrincipalLookupService lookupService = FileSystems.getDefault().getUserPrincipalLookupService();
+    GroupPrincipal group = lookupService.lookupPrincipalByGroupName(groupName);
+    Files.getFileAttributeView(jupyterJWT.tokenFile, PosixFileAttributeView.class,
+      LinkOption.NOFOLLOW_LINKS).setGroup(group);
+    
+    Files.setPosixFilePermissions(jupyterJWT.tokenFile, TOKEN_FILE_PERMISSIONS);
+  }
+
+  default void deleteToken(JupyterJWT jupyterJWT) {
+    FileUtils.deleteQuietly(jupyterJWT.tokenFile.toFile());
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/LocalJupyterJWTTokenWriter.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/LocalJupyterJWTTokenWriter.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.jupyter;
+
+import io.hops.hopsworks.common.integrations.LocalhostStereotype;
+
+import javax.ejb.Stateless;
+
+@Stateless
+@LocalhostStereotype
+public class LocalJupyterJWTTokenWriter implements JupyterJWTTokenWriter {
+
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/PidAndPort.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/PidAndPort.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.jupyter;
+
+import java.util.Objects;
+
+public class PidAndPort {
+  Long pid;
+  Integer port;
+
+  public PidAndPort(Long pid, Integer port) {
+    this.pid = pid;
+    this.port = port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PidAndPort that = (PidAndPort) o;
+    return Objects.equals(pid, that.pid) &&
+      Objects.equals(port, that.port);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pid, port);
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/TokenGenerator.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jupyter/TokenGenerator.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.jupyter;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+public class TokenGenerator {
+  
+  private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+  
+  private static ThreadLocal<Random> random = ThreadLocal.withInitial(() -> new SecureRandom());
+  
+  public static String generateToken(int length) {
+    StringBuilder token = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      token.append(ALPHABET.charAt(random.get().nextInt(ALPHABET.length())));
+    }
+    return token.toString();
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
@@ -61,6 +61,7 @@ import io.hops.hopsworks.common.dao.jobs.quota.YarnProjectsQuota;
 import io.hops.hopsworks.common.dao.jobs.quota.YarnProjectsQuotaFacade;
 import io.hops.hopsworks.common.dao.jupyter.JupyterProject;
 import io.hops.hopsworks.common.dao.jupyter.config.JupyterFacade;
+import io.hops.hopsworks.common.dao.jupyter.config.JupyterManager;
 import io.hops.hopsworks.common.dao.kafka.KafkaFacade;
 import io.hops.hopsworks.common.dao.log.operation.OperationType;
 import io.hops.hopsworks.common.dao.log.operation.OperationsLog;
@@ -207,6 +208,8 @@ public class ProjectController {
   private OperationsLogFacade operationsLogFacade;
   @EJB
   private EnvironmentController environmentController;
+  @Inject
+  private JupyterManager jupyterManager;
   @EJB
   private JobFacade jobFacade;
   @EJB

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -291,7 +291,6 @@ public class Settings implements Serializable {
   private static final String VARIABLE_SERVING_CONNECTION_POOL_SIZE = "serving_connection_pool_size";
   private static final String VARIABLE_SERVING_MAX_ROUTE_CONNECTIONS = "serving_max_route_connections";
 
-
   /*
    * -------------------- Kubernetes ---------------
    */
@@ -312,6 +311,14 @@ public class Settings implements Serializable {
   private static final String VARIABLE_KUBE_TF_IMG_VERSION = "kube_tf_img_version";
   private static final String VARIABLE_KUBE_SKLEARN_IMG_VERSION = "kube_sklearn_img_version";
   private static final String VARIABLE_KUBE_FILEBEAT_IMG_VERSION = "kube_filebeat_img_version";
+  private static final String VARIABLE_KUBE_JUPYTER_IMG_VERSION = "kube_jupyter_img_version";
+
+  private static final String VARIABLE_KUBE_API_MAX_ATTEMPTS = "kube_api_max_attempts";
+
+  /*
+   * -------------------- Jupyter ---------------
+   */
+  private static final String VARIABLE_JUPYTER_HOST = "jupyter_host";
 
   // JWT Variables
   private static final String VARIABLE_JWT_SIGNATURE_ALGORITHM = "jwt_signature_algorithm";
@@ -642,6 +649,10 @@ public class Settings implements Serializable {
       KUBE_TF_IMG_VERSION = setVar(VARIABLE_KUBE_TF_IMG_VERSION, KUBE_TF_IMG_VERSION);
       KUBE_SKLEARN_IMG_VERSION = setVar(VARIABLE_KUBE_SKLEARN_IMG_VERSION, KUBE_SKLEARN_IMG_VERSION);
       KUBE_FILEBEAT_IMG_VERSION = setVar(VARIABLE_KUBE_FILEBEAT_IMG_VERSION, KUBE_FILEBEAT_IMG_VERSION);
+      KUBE_JUPYTER_IMG_VERSION = setVar(VARIABLE_KUBE_JUPYTER_IMG_VERSION, KUBE_JUPYTER_IMG_VERSION);
+      KUBE_API_MAX_ATTEMPTS = setIntVar(VARIABLE_KUBE_API_MAX_ATTEMPTS, KUBE_API_MAX_ATTEMPTS);
+
+      JUPYTER_HOST = setStrVar(VARIABLE_JUPYTER_HOST, JUPYTER_HOST);
 
       JWT_SIGNATURE_ALGORITHM = setStrVar(VARIABLE_JWT_SIGNATURE_ALGORITHM, JWT_SIGNATURE_ALGORITHM);
       JWT_LIFETIME_MS = setLongVar(VARIABLE_JWT_LIFETIME_MS, JWT_LIFETIME_MS);
@@ -3256,6 +3267,12 @@ public class Settings implements Serializable {
     checkCache();
     return KUBE_MAX_SERVING_INSTANCES;
   }
+  
+  private Integer KUBE_API_MAX_ATTEMPTS = 12;
+  public synchronized Integer getKubeAPIMaxAttempts() {
+    checkCache();
+    return KUBE_API_MAX_ATTEMPTS;
+  }
 
   private String KUBE_TF_IMG_VERSION = "0.10.0";
   public synchronized String getKubeTfImgVersion() {
@@ -3275,6 +3292,12 @@ public class Settings implements Serializable {
     return KUBE_FILEBEAT_IMG_VERSION;
   }
 
+  private String KUBE_JUPYTER_IMG_VERSION = "0.10.0";
+  public synchronized String getJupyterImgVersion() {
+    checkCache();
+    return KUBE_JUPYTER_IMG_VERSION;
+  }
+
   private String SERVING_MONITOR_INT = "30s";
 
   public synchronized String getServingMonitorInt() {
@@ -3292,6 +3315,13 @@ public class Settings implements Serializable {
   public synchronized int getServingMaxRouteConnections() {
     checkCache();
     return SERVING_MAX_ROUTE_CONNECTIONS;
+  }
+
+  private String JUPYTER_HOST = "localhost";
+
+  public synchronized String getJupyterHost() {
+    checkCache();
+    return JUPYTER_HOST;
   }
 
   private String JWT_SIGNATURE_ALGORITHM = "HS512";


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1163

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR refactors the code in a way that allows an alternative implementation of JupyterProcessMgr and add support for running Jupyter on a remote host. It enable the extraction of configurations and secrets to be able to send them to a remote host. It also changes the way JWT tokens are being deleted for Jupyter to avoid a race condition. Additionally, this PR enables Hopsworks to set the token to be used by Jupyter explicitly.

* **What is the new behavior (if this is a feature change)?**
This code changes the way JWT token are being cleaned up for Jupyter. Instead of garbage collecting them in the background we now explicitly delete them when cleaning up Jupyter. This was necessary to avoid a race conditions which causes the JWTTokenManager to delete token for a new Jupyter instance while it is being started but hasn't been persisted to the database yet.

This code also changes the way we use Jupyter tokens as we now set them explicitly instead of extracting them from the logs.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
