### PR TITLE
[HOPSWORKS-1210] Jupyter now requires the python kernel.json to be under python{2, 3} dir

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
@@ -155,8 +155,8 @@ public class JupyterConfigFilesGenerator {
     return true;
   }
   
-  public String pythonKernelName() {
-    return "python";
+  public String pythonKernelName(String pythonVersion) {
+    return "python" + pythonVersion.charAt(0);
   }
   
   public String pythonKernelPath(String kernelsDir, String pythonKernelName) {
@@ -286,7 +286,7 @@ public class JupyterConfigFilesGenerator {
     boolean createdCustomJs = false;
     
     if (!jupyter_config_file.exists()) {
-      String pythonKernelName = pythonKernelName();
+      String pythonKernelName = pythonKernelName(project.getPythonVersion());
       if (settings.isPythonKernelEnabled() && !project.getPythonVersion().contains("X")) {
         String pythonKernelPath = pythonKernelPath(kernelsDir, pythonKernelName);
         File pythonKernelFile = new File(pythonKernelPath, JUPYTER_CUSTOM_KERNEL);

--- a/hopsworks-common/src/main/resources/io/hops/jupyter/jupyter_notebook_config_template.py
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/jupyter_notebook_config_template.py
@@ -25,7 +25,7 @@ c.JupyterConsoleApp.kernel_name="PySpark"
 
 c.KernelSpecManager.whitelist = {'pysparkkernel', 'sparkkernel', 'sparkrkernel','pythonwithpixiedustspark22'
 %%python-kernel%% }
-c.KernelSpecMAnager.ensure_native_kernel=False
+c.KernelSpecManager.ensure_native_kernel=False
 
 #Available kernels:
 #  sparkkernel                   /usr/local/share/jupyter/kernels/sparkkernel

--- a/hopsworks-common/src/main/resources/io/hops/jupyter/kernel_template.json
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/kernel_template.json
@@ -1,6 +1,6 @@
 {
-  "display_name": "python-%%hdfs_user%%",
-  "language": "python",
+  "display_name": "python",
+  "language": "python3",
   "argv": [
     "%%anaconda_home%%/bin/python",
     "-m",

--- a/hopsworks-common/src/main/resources/io/hops/jupyter/kernel_template.json
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/kernel_template.json
@@ -1,6 +1,6 @@
 {
-  "display_name": "python",
-  "language": "python3",
+  "display_name": "python-%%hdfs_user%%",
+  "language": "python",
   "argv": [
     "%%anaconda_home%%/bin/python",
     "-m",


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
