### PR TITLE
[HOPSWORKS-432] Clean Kafka ACLs when unsharing a topic or deleting a project

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/jobs/KafkaService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/jobs/KafkaService.java
@@ -259,6 +259,7 @@ public class KafkaService {
     RESTApiJsonResponse json = new RESTApiJsonResponse();
 
     kafkaFacade.unShareTopic(topicName, project.getId());
+    kafkaFacade.removeAclFromTopic(topicName, project);
     json.setSuccessMessage("Topic has been removed from shared.");
     return noCacheResponse.getNoCacheResponseBuilder(Response.Status.OK).entity(json).build();
   }
@@ -272,6 +273,7 @@ public class KafkaService {
     RESTApiJsonResponse json = new RESTApiJsonResponse();
 
     kafkaFacade.unShareTopic(topicName, project.getId());
+    kafkaFacade.removeAclFromTopic(topicName, project);
     json.setSuccessMessage("Topic has been removed from shared.");
     return noCacheResponse.getNoCacheResponseBuilder(Response.Status.OK).entity(json).build();
   }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/project/ProjectController.java
@@ -971,6 +971,8 @@ public class ProjectController {
     if (!project.getOwner().equals(user) && !usersController.isUserInRole(user, "HOPS_ADMIN")) {
       throw new ProjectException(RESTCodes.ProjectErrorCode.PROJECT_REMOVAL_NOT_ALLOWED, Level.FINE);
     }
+    
+    kafkaFacade.removeAclForProject(projectId);
 
     cleanup(project, sessionId);
   }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/projects/HOPSWORKS/issues/HOPSWORKS-432

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
Kafka ACLs are cleared after unsharing a topic or deleting a project

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

* **Other information**:
