### PR TITLE
[HOPSWORKS-1230] Support changing the schema of an existing Kafka topic

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/jobs/KafkaService.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/jobs/KafkaService.java
@@ -425,6 +425,17 @@ public class KafkaService {
     }
   }
   
+  @POST
+  @Path("/{topic}/schema/version/{version}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @AllowedProjectRoles({AllowedProjectRoles.DATA_OWNER, AllowedProjectRoles.DATA_SCIENTIST})
+  @JWTRequired(acceptedTokens = {Audience.API, Audience.JOB}, allowedUserRoles = {"HOPS_ADMIN", "HOPS_USER"})
+  public Response updateSchemaVersion(@PathParam("topic") String topic, @PathParam("version") Integer version)
+  throws KafkaException {
+    kafkaController.updateTopicSchemaVersion(project, topic, version);
+    return noCacheResponse.getNoCacheResponseBuilder(Response.Status.OK).build();
+  }
+  
 
   //This API used to select a schema and its version from the list
   //of available schemas when listing all the available schemas.

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/kafka/KafkaFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/kafka/KafkaFacade.java
@@ -92,6 +92,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
@@ -981,5 +982,31 @@ public class KafkaFacade {
     return partitionDetails;
   }
   
-
+  public Optional<ProjectTopics> getTopicByProjectAndTopicName(Project project, String topicName) {
+    try {
+      return Optional.of(em.createNamedQuery("ProjectTopics.findByProjectAndTopicName", ProjectTopics.class)
+        .setParameter("project", project)
+        .setParameter("topicName", topicName)
+        .getSingleResult());
+    } catch (NoResultException e) {
+      return Optional.empty();
+    }
+  }
+  
+  public Optional<SchemaTopics> getSchemaByNameAndVersion(String schemaName, Integer schemaVersion) {
+    try {
+      return Optional.of(em.createNamedQuery("SchemaTopics.findByNameAndVersion", SchemaTopics.class)
+        .setParameter("name", schemaName)
+        .setParameter("version", schemaVersion)
+        .getSingleResult());
+    } catch (NoResultException e) {
+      return Optional.empty();
+    }
+  }
+  
+  public void updateTopicSchemaVersion(ProjectTopics pt, SchemaTopics st) {
+    pt.setSchemaTopics(new SchemaTopics(st.schemaTopicsPK.getName(), st.schemaTopicsPK.getVersion()));
+    em.merge(pt);
+    em.flush();
+  }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/kafka/KafkaController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/kafka/KafkaController.java
@@ -43,6 +43,8 @@ import io.hops.hopsworks.common.dao.certificates.CertsFacade;
 import io.hops.hopsworks.common.dao.certificates.UserCerts;
 import io.hops.hopsworks.common.dao.kafka.AclDTO;
 import io.hops.hopsworks.common.dao.kafka.KafkaFacade;
+import io.hops.hopsworks.common.dao.kafka.ProjectTopics;
+import io.hops.hopsworks.common.dao.kafka.SchemaTopics;
 import io.hops.hopsworks.common.dao.kafka.SharedTopics;
 import io.hops.hopsworks.common.dao.kafka.TopicDTO;
 import io.hops.hopsworks.common.dao.project.Project;
@@ -50,11 +52,14 @@ import io.hops.hopsworks.common.dao.user.Users;
 import io.hops.hopsworks.exceptions.KafkaException;
 import io.hops.hopsworks.exceptions.ProjectException;
 import io.hops.hopsworks.exceptions.UserException;
+import io.hops.hopsworks.restutils.RESTCodes;
 import io.hops.hopsworks.common.util.Settings;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
@@ -169,4 +174,18 @@ public class KafkaController {
     return topics;
   }
 
+  public void updateTopicSchemaVersion(Project project, String topicName, Integer schemaVersion) throws KafkaException {
+    ProjectTopics pt = kafkaFacade.getTopicByProjectAndTopicName(project, topicName)
+      .orElseThrow(() ->
+        new KafkaException(RESTCodes.KafkaErrorCode.TOPIC_NOT_FOUND, Level.FINE,  "topic: " + topicName));
+    
+    String schemaName = pt.getSchemaTopics().getSchemaTopicsPK().getName();
+  
+    SchemaTopics st = kafkaFacade.getSchemaByNameAndVersion(schemaName, schemaVersion)
+      .orElseThrow(() ->
+        new KafkaException(RESTCodes.KafkaErrorCode.SCHEMA_VERSION_NOT_FOUND, Level.FINE,
+        "schema: " + schemaName + ", version: " + schemaVersion));
+    
+    kafkaFacade.updateTopicSchemaVersion(pt, st);
+  }
 }

--- a/hopsworks-rest-utils/src/main/java/io/hops/hopsworks/restutils/RESTCodes.java
+++ b/hopsworks-rest-utils/src/main/java/io/hops/hopsworks/restutils/RESTCodes.java
@@ -627,7 +627,8 @@ public class RESTCodes {
     CREATE_SCHEMA_RESERVED_NAME(16, "The provided schema name is reserved",
       Response.Status.METHOD_NOT_ALLOWED),
     DELETE_RESERVED_SCHEMA(17, "The schema is reserved and cannot be deleted",
-      Response.Status.METHOD_NOT_ALLOWED);
+      Response.Status.METHOD_NOT_ALLOWED),
+    SCHEMA_VERSION_NOT_FOUND(18, "Specified version of the schema not found", Response.Status.NOT_FOUND);
 
 
     private Integer code;

--- a/hopsworks-web/yo/app/scripts/controllers/kafkaCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/kafkaCtrl.js
@@ -434,6 +434,7 @@ angular.module('hopsWorksApp')
 
               self.getAllTopics();
               self.getAllSharedTopics();
+              self.listSchemas();
              };
             
             self.init();
@@ -453,6 +454,16 @@ angular.module('hopsWorksApp')
               self.showSchemas = 1;
               self.showTopics = -1;
               self.listSchemas();
+            };
+
+            self.updateSchemaVersion = function(topicName, schemaVersion) {
+                KafkaService.updateTopicSchemaVersion(self.projectId, topicName, schemaVersion).then(
+                    function(success) {
+                        growl.success("", {title: 'Schema version successfully updated.', ttl: 5000});
+                    }, function (error) {
+                        growl.error("", {title: "Error updating schema version", ttl: 8000, referenceId: 10});
+                    }
+                )
             };
               
           }]);

--- a/hopsworks-web/yo/app/scripts/services/KafkaService.js
+++ b/hopsworks-web/yo/app/scripts/services/KafkaService.js
@@ -236,6 +236,14 @@ angular.module('hopsWorksApp')
               
               topicIsSharedTo: function (projectId, topicName){
                   return $http.get('/api/project/' + projectId + '/kafka/'+topicName+'/sharedwith');
+              },
+
+              updateTopicSchemaVersion: function (projectId, topicName, schemaVersion) {
+                  var req = {
+                      method: 'POST',
+                      url: '/api/project/' + projectId + '/kafka/' + topicName + '/schema/version/' + schemaVersion,
+                  };
+                  return $http(req);
               }
               
             };

--- a/hopsworks-web/yo/app/views/kafka.html
+++ b/hopsworks-web/yo/app/views/kafka.html
@@ -104,8 +104,9 @@
             <table st-table="rowCollection" class="table table-striped" ng-show="kafkaCtrl.topics.length > 0">
               <thead>
                 <tr>
-                  <th st-sort="topicName" class="col-sm-7">Topic Name</th>
-                  <th class="col-sm-1">Schema (v)  </th>
+                  <th st-sort="topicName" class="col-sm-6">Topic Name</th>
+                  <th class="col-sm-1">Schema</th>
+                  <th class="col-sm-1">Version</th>
                   <th class="col-sm-1">ACL</th>
                   <th class="col-sm-1">Share</th>
                   <th class="col-sm-1">Advanced</th>
@@ -254,8 +255,21 @@
             </table>
 
             </td>
-            <td class="col-sm-1" style="vertical-align: top !important;">
-              {{row.schemaName}} ({{row.schemaVersion}})
+            <td class="col-sm-1 form-inline" style="vertical-align: top !important;">
+              {{row.schemaName}}
+            </td>
+
+            <td class="col-sm-1 form-inline" style="vertical-align: top !important;">
+              <ui-select style="min-width: 70px;" name="schema_topic_version" theme="select2" style="margin-left: 10px"
+                         ng-model="row.schemaVersion"
+                         ng-change="kafkaCtrl.updateSchemaVersion(row.name, row.schemaVersion)" required>
+
+                <ui-select-match placeholder="version">{{$select.selected}}</ui-select-match>
+
+                <ui-select-choices repeat="version in (kafkaCtrl.schemas | filter:{name:row.schemaName})[0].versions | orderBy: version | filter: $select.search">
+                  <div ng-bind-html="version | highlight: $select.search"></div>
+                </ui-select-choices>
+              </ui-select>
             </td>
 
             <td class="col-sm-1" style="vertical-align: top !important;">


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1230

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds support for changing the schema of an existing Kafka topic

* **What is the new behavior (if this is a feature change)?**
In the Kafka tab, next to the schema version appears a button to change the version. A user is presented a pop-up window with a list of available schema versions.

![Screenshot from 2019-08-19 17-17-50](https://user-images.githubusercontent.com/32437462/63281766-569c7f80-c2a5-11e9-8abe-88dca53cd629.png)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:

