### PR TITLE
[HOPSWORKS-453] Do not configure pyspark archives

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -268,7 +268,6 @@ public class Settings implements Serializable {
   private static final String VARIABLE_TEZ_VERSION = "tez_version";
   private static final String VARIABLE_SLIDER_VERSION = "slider_version";
   private static final String VARIABLE_SPARK_VERSION = "spark_version";
-  private static final String VARIABLE_PY4J_ARCHIVE = "py4j_version";
   private static final String VARIABLE_FLINK_VERSION = "flink_version";
   private static final String VARIABLE_EPIPE_VERSION = "epipe_version";
   private static final String VARIABLE_DELA_VERSION = "dela_version";
@@ -484,7 +483,6 @@ public class Settings implements Serializable {
       YARN_SUPERUSER = setVar(VARIABLE_YARN_SUPERUSER, YARN_SUPERUSER);
       SPARK_USER = setVar(VARIABLE_SPARK_USER, SPARK_USER);
       SPARK_DIR = setDirVar(VARIABLE_SPARK_DIR, SPARK_DIR);
-      PY4J_ARCHIVE = setVar(VARIABLE_PY4J_ARCHIVE, PY4J_ARCHIVE);
       FLINK_USER = setVar(VARIABLE_FLINK_USER, FLINK_USER);
       FLINK_DIR = setDirVar(VARIABLE_FLINK_DIR, FLINK_DIR);
       STAGING_DIR = setDirVar(VARIABLE_STAGING_DIR, STAGING_DIR);
@@ -861,17 +859,9 @@ public class Settings implements Serializable {
   //PYSPARK constants
   public static final String SPARK_PY_MAINCLASS
       = "org.apache.spark.deploy.PythonRunner";
-  public static final String PYSPARK_ZIP = "pyspark.zip";
 
   //Hive config
   public static final String HIVE_SITE = "hive-site.xml";
-
-  private String PY4J_ARCHIVE = "py4j-0.10.7-src.zip";
-
-  public synchronized String getPy4JArchive() {
-    checkCache();
-    return PY4J_ARCHIVE;
-  }
 
   public synchronized String getSparkDir() {
     checkCache();
@@ -1273,18 +1263,6 @@ public class Settings implements Serializable {
 
   public String getFlinkDefaultClasspath(String flinkDir) {
     return flinkDefaultClasspath(flinkDir);
-  }
-
-  public String getLocalSparkJarPath() {
-    return getSparkDir() + "/spark.jar";
-  }
-
-  public String getHdfsSparkJarPath() {
-    return "hdfs:///user/" + getSparkUser() + "/spark-jars.zip";
-  }
-
-  public String getPySparkLibsPath() {
-    return getSparkDir() + "/python/lib/";
   }
 
   public String getSparkLog4JPath() {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
@@ -116,16 +116,6 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
       }
     }
 
-    String py4jArchive = settings.getPySparkLibsPath() + "/" + settings.getPy4JArchive();
-    String sparkjars = settings.getPySparkLibsPath() + "/" + settings.PYSPARK_ZIP;
-
-    StringBuilder pyFilesDist = new StringBuilder();
-    pyFilesDist.append(sparkjars).append(",").append(py4jArchive);
-
-    sparkProps.put(Settings.SPARK_YARN_DIST_PYFILES, new ConfigProperty(
-      Settings.SPARK_YARN_DIST_PYFILES, HopsUtils.APPEND_COMMA,
-      pyFilesDist.toString()));
-
     addToSparkEnvironment(sparkProps, "SPARK_HOME", settings.getSparkDir(), HopsUtils.IGNORE);
     addToSparkEnvironment(sparkProps, "SPARK_CONF_DIR", settings.getSparkConfDir(), HopsUtils.IGNORE);
     addToSparkEnvironment(sparkProps, "ELASTIC_ENDPOINT", settings.getElasticRESTEndpoint(), HopsUtils.IGNORE);


### PR DESCRIPTION
The archives are configured in the environment to be used
from the local installation. Remove the duplicated configuration
here to avoid uploading them unnecessarily.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
