### PR TITLE
[HOPSWORKS-1258] Remove configuration for hops-util

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -231,7 +231,6 @@ public class Settings implements Serializable {
 
   private static final String VARIABLE_DOWNLOAD_ALLOWED = "download_allowed";
   private static final String VARIABLE_SUPPORT_EMAIL_ADDR = "support_email_addr";
-  private static final String VARIABLE_HOPSUTIL_VERSION = "hopsutil_version";
   private static final String VARIABLE_HOPSEXAMPLES_VERSION = "hopsexamples_version";
 
   private static final String VARIABLE_INFLUXDB_IP = "influxdb_ip";
@@ -488,7 +487,6 @@ public class Settings implements Serializable {
       FLINK_USER = setVar(VARIABLE_FLINK_USER, FLINK_USER);
       FLINK_DIR = setDirVar(VARIABLE_FLINK_DIR, FLINK_DIR);
       STAGING_DIR = setDirVar(VARIABLE_STAGING_DIR, STAGING_DIR);
-      HOPSUTIL_VERSION = setVar(VARIABLE_HOPSUTIL_VERSION, HOPSUTIL_VERSION);
       HOPS_EXAMPLES_VERSION = setVar(VARIABLE_HOPSEXAMPLES_VERSION, HOPS_EXAMPLES_VERSION);
       HIVE_SERVER_HOSTNAME = setStrVar(VARIABLE_HIVE_SERVER_HOSTNAME,
           HIVE_SERVER_HOSTNAME);
@@ -2293,17 +2291,6 @@ public class Settings implements Serializable {
   public synchronized String getPyPiRESTEndpoint() {
     checkCache();
     return PYPI_REST_ENDPOINT;
-  }
-
-  private String HOPSUTIL_VERSION = "0.3.0";
-
-  public String getHopsUtilHdfsPath() {
-    return "hdfs:///user/" + getSparkUser() + "/" + getHopsUtilFilename();
-  }
-
-  public synchronized String getHopsUtilFilename() {
-    checkCache();
-    return "hops-util-" + HOPSUTIL_VERSION + ".jar";
   }
 
   private String HOPS_EXAMPLES_VERSION = "0.3.0";

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
@@ -342,9 +342,6 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
             // Glassfish domain truststore
             .append(settings.getGlassfishTrustStoreHdfs()).append("#").append(Settings.DOMAIN_CA_TRUSTSTORE)
             .append(",")
-            // Add HopsUtil
-            .append(settings.getHopsUtilHdfsPath())
-            .append(",")
             // Add Hive-site.xml for SparkSQL
             .append(settings.getHiveSiteSparkHdfsPath());
 
@@ -353,8 +350,6 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
       .append("{{PWD}}")
       .append(File.pathSeparator)
       .append(settings.getHopsLeaderElectionJarPath())
-      .append(File.pathSeparator)
-      .append(settings.getHopsUtilFilename())
       .append(File.pathSeparator)
       .append(settings.getSparkDir() + "/jars/*");
 


### PR DESCRIPTION
Remove the explicit configuration of hops-util as it is being put
into the classpath by placing it into the Spark jars folder to speed
up application startup times.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
