### PR TITLE
[HOPSWORKS-1264] [featurestore] import functionality

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/settings/FeaturestoreClientSettingsDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/settings/FeaturestoreClientSettingsDTO.java
@@ -95,6 +95,7 @@ public class FeaturestoreClientSettingsDTO {
   private String featurestoreUtil4jExecutable = FeaturestoreConstants.FEATURESTORE_UTIL_4J_EXECUTABLE;
   private String featurestoreUtilPythonExecutable = FeaturestoreConstants.FEATURESTORE_UTIL_PYTHON_EXECUTABLE;
   private String s3BucketTrainingDatasetsFolder = FeaturestoreConstants.S3_BUCKET_TRAINING_DATASETS_FOLDER;
+  private List<String> featureImportConnectors = FeaturestoreConstants.FEATURE_IMPORT_CONNECTORS;
   
   
   public FeaturestoreClientSettingsDTO() {
@@ -522,5 +523,14 @@ public class FeaturestoreClientSettingsDTO {
   
   public void setS3BucketTrainingDatasetsFolder(String s3BucketTrainingDatasetsFolder) {
     this.s3BucketTrainingDatasetsFolder = s3BucketTrainingDatasetsFolder;
+  }
+  
+  @XmlElement
+  public List<String> getFeatureImportConnectors() {
+    return featureImportConnectors;
+  }
+  
+  public void setFeatureImportConnectors(List<String> featureImportConnectors) {
+    this.featureImportConnectors = featureImportConnectors;
   }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featorestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featorestore/FeaturestoreConstants.java
@@ -94,5 +94,6 @@ public class FeaturestoreConstants {
   public static final String FEATURESTORE_UTIL_PYTHON_EXECUTABLE =
     "/user/spark/featurestore_util.py";
   public static final String S3_BUCKET_TRAINING_DATASETS_FOLDER = "TRAINING_DATASETS";
+  public static final List<String> FEATURE_IMPORT_CONNECTORS = Arrays.asList(new String[]{S3_CONNECTOR_TYPE});
   
 }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1264

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature

* **What is the new behavior (if this is a feature change)?**
Users can now import existing feature datasets on external storage layers, e.g S3, into the Hopsworks feature store

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No