### PR TITLE
[HOPSWORKS-1220] propagate certs-dir to hops-util

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/jupyter/config/JupyterConfigFilesGenerator.java
@@ -224,7 +224,8 @@ public class JupyterConfigFilesGenerator {
         "remote_git_url", remoteGitURL,
         "api_key", apiKey,
         "base_branch", baseBranch,
-        "head_branch", headBranch
+        "head_branch", headBranch,
+        "kagent_certs_dir", settings.getKagentCertsDir()
       ).toString();
   }
   

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -276,6 +276,7 @@ public class Settings implements Serializable {
   private static final String VARIABLE_TENSORFLOW_VERSION = "tensorflow_version";
   private static final String VARIABLE_CUDA_VERSION = "cuda_version";
   private static final String VARIABLE_HOPSWORKS_VERSION = "hopsworks_version";
+  private static final String VARIABLE_KAGENT_CERTS_DIR = "kagent_certs_dir";
 
   //Used by RESTException to include devMsg or not in response
   private static final String VARIABLE_HOPSWORKS_REST_LOG_LEVEL = "hopsworks_rest_log_level";
@@ -672,6 +673,8 @@ public class Settings implements Serializable {
       FEATURESTORE_DB_DEFAULT_QUOTA = setStrVar(VARIABLE_FEATURESTORE_DEFAULT_QUOTA, FEATURESTORE_DB_DEFAULT_QUOTA);
       FEATURESTORE_DB_DEFAULT_STORAGE_FORMAT =
           setStrVar(VARIABLE_FEATURESTORE_DEFAULT_STORAGE_FORMAT, FEATURESTORE_DB_DEFAULT_STORAGE_FORMAT);
+  
+      KAGENT_CERTS_DIR = setStrVar(VARIABLE_KAGENT_CERTS_DIR, KAGENT_CERTS_DIR);
 
       cached = true;
     }
@@ -3429,6 +3432,13 @@ public class Settings implements Serializable {
 
   public Boolean isHopsUtilInsecure() {
     return isCloud() || isLocalHost();
+  }
+  
+  private String KAGENT_CERTS_DIR = "/srv/hops/kagent/host-certs";
+  
+  public synchronized String getKagentCertsDir() {
+    checkCache();
+    return KAGENT_CERTS_DIR;
   }
 
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
@@ -151,6 +151,7 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
             HopsUtils.IGNORE);
     addToSparkEnvironment(sparkProps, "HOPSWORKS_PROJECT_ID", Integer.toString(project.getId()),
             HopsUtils.IGNORE);
+    addToSparkEnvironment(sparkProps, "KAGENT_CERTS_DIR", settings.getKagentCertsDir(), HopsUtils.IGNORE);
     //If DynamicExecutors are not enabled, set the user defined number
     //of executors
 

--- a/hopsworks-common/src/main/resources/io/hops/jupyter/jupyter_notebook_config_template.py
+++ b/hopsworks-common/src/main/resources/io/hops/jupyter/jupyter_notebook_config_template.py
@@ -50,6 +50,7 @@ os.environ['HADOOP_USER_NAME'] = "%%hdfs_user%%"
 os.environ['JUPYTER_CERTS_DIR'] = "%%jupyter_certs_dir%%"
 os.environ['HOPSWORKS_PROJECT_ID'] = "%%hopsworks_project_id%%"
 os.environ['HADOOP_HOME'] = "%%hadoop_home%%"
+os.environ['KAGENT_CERTS_DIR'] = "%%kagent_certs_dir%%"
 
 c.GitHandlersConfiguration.remote_git_url = "%%remote_git_url%%"
 c.GitHandlersConfiguration.api_key = "%%api_key%%"


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1220

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature
* **What is the new behavior (if this is a feature change)?**
Propagate kagent certs dir properly to client libraries

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
* **Other information**:
