### PR TITLE
[HOPSWORKS-1302] Add endpoint for creating jobs to create training datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ glassfish-resources.xml
 nb-configuration.xml
 nbactions.xml
 
+### MacOS ###
+.DS_Store
+
 ### Intellj ###
 hopsworks-web/overlays/
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobController.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.dao.featurestore.trainingdatasetjob;
+
+import io.hops.hopsworks.common.integrations.CommunityStereotype;
+
+import javax.ejb.Stateless;
+
+@Stateless
+@CommunityStereotype
+public class TrainingDatasetJobController {
+
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobController.java
@@ -22,6 +22,6 @@ import javax.ejb.Stateless;
 
 @Stateless
 @CommunityStereotype
-public class TrainingDatasetJobController {
+public class TrainingDatasetJobController implements TrainingDatasetJobControllerIface {
 
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobControllerIface.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobControllerIface.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.dao.featurestore.trainingdatasetjob;
+
+import io.hops.hopsworks.common.dao.jobs.description.Jobs;
+import io.hops.hopsworks.common.dao.project.Project;
+import io.hops.hopsworks.common.dao.user.Users;
+import io.hops.hopsworks.exceptions.FeaturestoreException;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.xml.bind.JAXBException;
+
+public interface TrainingDatasetJobControllerIface {
+  @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+  default Jobs createTrainingDatasetJob(Users user, Project project, TrainingDatasetJobDTO
+    trainingDatasetJobDTO) throws FeaturestoreException, JAXBException {
+    throw new RuntimeException("API not supported in the community edition");
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dao/featurestore/trainingdatasetjob/TrainingDatasetJobDTO.java
@@ -1,0 +1,319 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.common.dao.featurestore.trainingdatasetjob;
+
+import io.hops.hopsworks.common.util.Settings;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+/**
+ * DTO for featurestore cloud jobs
+ */
+
+@XmlRootElement
+public class TrainingDatasetJobDTO {
+  
+  @XmlElement(name="features")
+  private List<String> features;
+  @XmlElement(name="training_dataset")
+  private String trainingDataset;
+  @XmlElement(name="featuregroups_version_dict")
+  private String featuregroupsVersionDict;
+  @XmlElement(name="join_key", nillable = true)
+  private String joinKey;
+  @XmlElement(name="description")
+  private String description;
+  @XmlElement(name="featurestore", nillable = true)
+  private String featurestore;
+  @XmlElement(name="data_format")
+  private String dataFormat;
+  @XmlElement(name="training_dataset_version")
+  private int trainingDatasetVersion;
+  @XmlElement(name="overwrite")
+  private Boolean overwrite;
+  @XmlElement(name="jobs")
+  private List<String> jobs;
+  @XmlElement(name="descriptive_statistics")
+  private Boolean descriptiveStatistics;
+  @XmlElement(name="feature_correlation")
+  private Boolean featureCorrelation;
+  @XmlElement(name="feature_histograms")
+  private Boolean featureHistograms;
+  @XmlElement(name="cluster_analysis")
+  private Boolean clusterAnalysis;
+  @XmlElement(name="stat_columns", nillable = true)
+  private List<String> statColumns;
+  @XmlElement(name="num_bins")
+  private int numBins;
+  @XmlElement(name="correlation_method")
+  private String correlationMethod;
+  @XmlElement(name="num_clusters")
+  private int numClusters;
+  @XmlElement(name="fixed")
+  private Boolean fixed;
+  @XmlElement(name="sink", nillable = true)
+  private String sink;
+  @XmlElement(name="am_cores")
+  private int amCores = 1;
+  @XmlElement(name="am_memory")
+  private int amMemory = Settings.YARN_DEFAULT_APP_MASTER_MEMORY;;
+  @XmlElement(name="executor_cores")
+  private int executorCores = 1;
+  @XmlElement(name="executor_memory")
+  private int executorMemory = 4096;
+  @XmlElement(name="max_executors")
+  private int maxExecutors = 2;
+  
+  
+  public TrainingDatasetJobDTO(
+    List<String> features, String trainingDataset, String featuregroupsVersionDict, String joinKey,
+    String description, String featurestore, String dataFormat, int trainingDatasetVersion, Boolean
+    overwrite, List<String> jobs, Boolean descriptiveStatistics, Boolean featureCorrelation, Boolean featureHistograms,
+    Boolean clusterAnalysis, List<String> statColumns, int numBins, String correlationMethod, int numClusters,
+    Boolean fixed, String sink, int amCores, int amMemory, int executorCores, int executorMemory, int maxExecutors) {
+    this.features = features;
+    this.trainingDataset = trainingDataset;
+    this.featuregroupsVersionDict = featuregroupsVersionDict;
+    this.joinKey = joinKey;
+    this.description = description;
+    this.featurestore = featurestore;
+    this.dataFormat = dataFormat;
+    this.trainingDatasetVersion = trainingDatasetVersion;
+    this.overwrite = overwrite;
+    this.jobs = jobs;
+    this.descriptiveStatistics = descriptiveStatistics;
+    this.featureCorrelation = featureCorrelation;
+    this.featureHistograms = featureHistograms;
+    this.clusterAnalysis = clusterAnalysis;
+    this.statColumns = statColumns;
+    this.numBins = numBins;
+    this.correlationMethod = correlationMethod;
+    this.numClusters = numClusters;
+    this.fixed = fixed;
+    this.sink = sink;
+    this.amCores = amCores;
+    this.amMemory = amMemory;
+    this.executorCores = executorCores;
+    this.executorMemory = executorMemory;
+    this.maxExecutors = maxExecutors;
+  }
+  
+  public TrainingDatasetJobDTO() {
+  }
+  
+  public List<String> getFeatures() {
+    return features;
+  }
+  
+  public void setFeatures(List<String> features) {
+    this.features = features;
+  }
+  
+  public String getTrainingDataset() {
+    return trainingDataset;
+  }
+  
+  public void setTrainingDataset(String trainingDataset) {
+    this.trainingDataset = trainingDataset;
+  }
+  
+  public String getFeaturegroupsVersionDict() {
+    return this.featuregroupsVersionDict;
+  }
+  
+  public void setFeaturegroupsVersionDict(String featuregroupsVersionDict) {
+    this.featuregroupsVersionDict = featuregroupsVersionDict;
+  }
+  
+  public String getJoinKey() {
+    return joinKey;
+  }
+  
+  public void setJoinKey(String joinKey) {
+    this.joinKey = joinKey;
+  }
+  
+  public String getDescription() {
+    return description;
+  }
+  
+  public void setDescription(String description) {
+    this.description = description;
+  }
+  
+  public String getFeaturestore() {
+    return featurestore;
+  }
+  
+  public void setFeaturestore(String featurestore) {
+    this.featurestore = featurestore;
+  }
+  
+  public String getDataFormat() {
+    return dataFormat;
+  }
+  
+  public void setDataFormat(String dataFormat) {
+    this.dataFormat = dataFormat;
+  }
+  
+  public int getTrainingDatasetVersion() {
+    return trainingDatasetVersion;
+  }
+  
+  public void setTrainingDatasetVersion(int trainingDatasetVersion) {
+    this.trainingDatasetVersion = trainingDatasetVersion;
+  }
+  
+  public Boolean getOverwrite() {
+    return overwrite;
+  }
+  
+  public void setOverwrite(Boolean overwrite) {
+    this.overwrite = overwrite;
+  }
+  
+  public List<String> getJobs() {
+    return jobs;
+  }
+  
+  public void setJobs(List<String> jobs) {
+    this.jobs = jobs;
+  }
+  
+  public Boolean getDescriptiveStatistics() {
+    return descriptiveStatistics;
+  }
+  
+  public void setDescriptiveStatistics(Boolean descriptiveStatistics) {
+    this.descriptiveStatistics = descriptiveStatistics;
+  }
+  
+  public Boolean getFeatureCorrelation() {
+    return featureCorrelation;
+  }
+  
+  public void setFeatureCorrelation(Boolean featureCorrelation) {
+    this.featureCorrelation = featureCorrelation;
+  }
+  
+  public Boolean getFeatureHistograms() {
+    return featureHistograms;
+  }
+  
+  public void setFeatureHistograms(Boolean featureHistograms) {
+    this.featureHistograms = featureHistograms;
+  }
+  
+  public Boolean getClusterAnalysis() {
+    return clusterAnalysis;
+  }
+  
+  public void setClusterAnalysis(Boolean clusterAnalysis) {
+    this.clusterAnalysis = clusterAnalysis;
+  }
+  
+  public List<String> getStatColumns() {
+    return statColumns;
+  }
+  
+  public void setStatColumns(List<String> statColumns) {
+    this.statColumns = statColumns;
+  }
+  
+  public int getNumBins() {
+    return numBins;
+  }
+  
+  public void setNumBins(int numBins) {
+    this.numBins = numBins;
+  }
+  
+  public String getCorrelationMethod() {
+    return correlationMethod;
+  }
+  
+  public void setCorrelationMethod(String correlationMethod) {
+    this.correlationMethod = correlationMethod;
+  }
+  
+  public int getNumClusters() {
+    return numClusters;
+  }
+  
+  public void setNumClusters(int numClusters) {
+    this.numClusters = numClusters;
+  }
+  
+  public Boolean getFixed() {
+    return fixed;
+  }
+  
+  public void setFixed(Boolean fixed) {
+    this.fixed = fixed;
+  }
+  
+  public String getSink() {
+    return sink;
+  }
+  
+  public void setSink(String sink) {
+    this.sink = sink;
+  }
+  
+  public int getAmCores() {
+    return amCores;
+  }
+  
+  public void setAmCores(int amCores) {
+    this.amCores = amCores;
+  }
+  
+  public int getAmMemory() {
+    return amMemory;
+  }
+  
+  public void setAmMemory(int amMemory) {
+    this.amMemory = amMemory;
+  }
+  
+  public int getExecutorCores() {
+    return executorCores;
+  }
+  
+  public void setExecutorCores(int executorCores) {
+    this.executorCores = executorCores;
+  }
+  
+  public int getExecutorMemory() {
+    return executorMemory;
+  }
+  
+  public void setExecutorMemory(int executorMemory) {
+    this.executorMemory = executorMemory;
+  }
+  
+  public int getMaxExecutors() {
+    return maxExecutors;
+  }
+  
+  public void setMaxExecutors(int maxExecutors) {
+    this.maxExecutors = maxExecutors;
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featorestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featorestore/FeaturestoreConstants.java
@@ -111,5 +111,4 @@ public class FeaturestoreConstants {
   public static final int ONLINE_FEATURESTORE_USERNAME_MAX_LENGTH = 32;
   public static final int ONLINE_FEATURESTORE_PW_LENGTH = 32;
   public static final String FEATURESTORE_HIVE_DB_SUFFIX = "_featurestore";
-
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -2021,7 +2021,21 @@ public class Settings implements Serializable {
     checkCache();
     return "hdfs:///user" + Path.SEPARATOR + getSparkUser() + Path.SEPARATOR + FEATURESTORE_IMPORT_JOB_NAME;
   }
-
+  
+  private static final String FEATURESTORE_TRAININGDATASET_JOB_PARENT_DIR = "featurestore-trainingdataset-job";
+  public static final String FEATURESTORE_TRAININGDATASET_JOB_CONF = "configurations";
+  public static final String FEATURESTORE_TRAININGDATASET_JOB_NAME = "ft_trainingdataset_job.py";
+  
+  public String getBaseFeaturestoreTrainingDatasetJobDir(Project project) {
+    return Utils.getProjectPath(project.getName()) + Settings.BaseDataset.RESOURCES.getName() + Path.SEPARATOR +
+      Settings.FEATURESTORE_TRAININGDATASET_JOB_PARENT_DIR + Path.SEPARATOR;
+  }
+  
+  public synchronized String getFeaturestoreTrainingDatasetJobPath() {
+    checkCache();
+    return "hdfs:///user" + Path.SEPARATOR + getSparkUser() + Path.SEPARATOR + FEATURESTORE_TRAININGDATASET_JOB_NAME;
+  }
+  
   public Settings() {
   }
 

--- a/hopsworks-rest-utils/src/main/java/io/hops/hopsworks/restutils/RESTCodes.java
+++ b/hopsworks-rest-utils/src/main/java/io/hops/hopsworks/restutils/RESTCodes.java
@@ -1353,8 +1353,16 @@ public class RESTCodes {
         Response.Status.INTERNAL_SERVER_ERROR),
     IMPORT_JOB_ALREADY_RUNNING(78, "A job to import this featuregroup is already running",
         Response.Status.BAD_REQUEST),
-    IMPORT_CONF_ERROR(79, "Error writing import job configuration", Response.Status.INTERNAL_SERVER_ERROR);
-
+    IMPORT_CONF_ERROR(79, "Error writing import job configuration", Response.Status.INTERNAL_SERVER_ERROR),
+    TRAININGDATASETJOB_FAILURE(80, "Could not write featurestore cloud args to HDFS",
+      Response.Status.INTERNAL_SERVER_ERROR),
+    TRAININGDATASETJOB_DUPLICATE_FEATURE(81, "Feature list contains duplicate", Response.Status.BAD_REQUEST),
+    TRAININGDATASETJOB_FEATURE_NOT_EXISTING(82, "Feature does not exist", Response.Status.BAD_REQUEST),
+    TRAININGDATASETJOB_FEATUREGROUP_DUPLICATE(83, "Multiple featuregroups contain feature",
+      Response.Status.BAD_REQUEST),
+    TRAININGDATASETJOB_TRAININGDATASET_VERSION_EXISTS(84, "Illegal training dataset name - version combination",
+      Response.Status.BAD_REQUEST);
+    
     private int code;
     private String message;
     private Response.Status respStatus;


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1302

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Rest endpoint in enterprise version to send json with job configuration to Hopsworks. This PR is to track the common changes required in the community edition.

* **What is the new behavior (if this is a feature change)?**
Community Edition will throw not implemented error when a request is sent to the new endpoint.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: