### PR TITLE
[HOPSWORKS-1362] Add endpoint for platform admins or agents to get users' x.509 credentials. Required by WebHDFS

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/admin_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/admin_spec.rb
@@ -82,4 +82,51 @@ describe "On #{ENV['OS']}" do
     end
     
   end
+
+  describe "#credentials" do
+    describe "#get x509 credentials" do
+      before :all do
+        reset_session
+      end
+
+      context "#not logged in" do
+        it "should fail" do
+          get "#{ENV['HOPSWORKS_API']}/admin/credentials/x509?project=some_project&username=some_username"
+          expect_status(401)
+        end
+      end
+
+      context "#logged in a normal user" do
+        before :all do
+          with_valid_session
+        end
+
+        it "should fail" do
+          get "#{ENV['HOPSWORKS_API']}/admin/credentials/x509?project=some_project&username=some_username"
+          expect_status(403)
+        end
+      end
+
+      context "#logged in as admin or agent" do
+        before :all do
+          reset_session
+          with_valid_project
+          @project_user = @user
+          with_admin_session
+        end
+
+        it "should succeed to get credentials" do
+          get "#{ENV['HOPSWORKS_API']}/admin/credentials/x509?project=#{@project[:projectname]}&username=#{@project_user[:username]}"
+          expect_status(200)
+          expect(json_body[:fileExtension]).to eql("jks")
+          expect(json_body[:kStore]).not_to be_nil
+          expect(json_body[:tStore]).not_to be_nil
+          expect(json_body[:password]).not_to be_nil
+          with_agent_session
+          get "#{ENV['HOPSWORKS_API']}/admin/credentials/x509?project=#{@project[:projectname]}&username=#{@project_user[:username]}"
+          expect_status(200)
+        end
+      end
+    end
+  end
 end

--- a/hopsworks-IT/src/test/ruby/spec/helpers/session_helper.rb
+++ b/hopsworks-IT/src/test/ruby/spec/helpers/session_helper.rb
@@ -52,9 +52,9 @@ module SessionHelper
   end
   
   def with_admin_session
-    user = create_user_without_role({})
-    create_admin_role(user)
-    create_session(user.email, "Pass123")
+    @user = create_user_without_role({})
+    create_admin_role(@user)
+    create_session(@user.email, "Pass123")
   end
 
   def with_agent_session

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/security/CertificateMaterializerAdmin.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/security/CertificateMaterializerAdmin.java
@@ -37,7 +37,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package io.hops.hopsworks.api.admin;
+package io.hops.hopsworks.api.admin.security;
 
 import com.google.common.base.Strings;
 import io.hops.hopsworks.api.admin.dto.MaterializerStateResponse;

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/security/CredentialsResource.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/security/CredentialsResource.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.api.admin.security;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@RequestScoped
+@Path("/admin/credentials")
+@TransactionAttribute(TransactionAttributeType.NEVER)
+public class CredentialsResource {
+  
+  @Inject
+  private X509Resource x509Resource;
+  
+  @Path("/x509")
+  public X509Resource getX509Credentials() {
+    return x509Resource;
+  }
+}

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/security/X509Resource.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/security/X509Resource.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.api.admin.security;
+
+import io.hops.hopsworks.api.filter.Audience;
+import io.hops.hopsworks.common.dao.user.UserFacade;
+import io.hops.hopsworks.common.dao.user.Users;
+import io.hops.hopsworks.common.hdfs.HdfsUsersController;
+import io.hops.hopsworks.common.project.AccessCredentialsDTO;
+import io.hops.hopsworks.common.project.ProjectController;
+import io.hops.hopsworks.common.project.ProjectDTO;
+import io.hops.hopsworks.exceptions.DatasetException;
+import io.hops.hopsworks.exceptions.HopsSecurityException;
+import io.hops.hopsworks.exceptions.ProjectException;
+import io.hops.hopsworks.exceptions.UserException;
+import io.hops.hopsworks.jwt.annotation.JWTRequired;
+import io.hops.hopsworks.restutils.RESTCodes;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+import javax.ejb.EJB;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.logging.Level;
+
+@RequestScoped
+@Api(value = "API for platform admins or agents to access x509 credentials of users")
+public class X509Resource {
+  
+  @EJB
+  private ProjectController projectController;
+  @EJB
+  private UserFacade userFacade;
+  @EJB
+  private HdfsUsersController hdfsUsersController;
+  
+  @GET
+  @TransactionAttribute(TransactionAttributeType.NEVER)
+  @Produces(MediaType.APPLICATION_JSON)
+  @JWTRequired(acceptedTokens = {Audience.SERVICES, Audience.API}, allowedUserRoles = {"AGENT", "HOPS_ADMIN"})
+  @ApiOperation(value = "Get keystore, truststore and password of a project user",
+    response = AccessCredentialsDTO.class)
+  public Response getx509(@QueryParam("username") String projectUsername)
+    throws ProjectException, UserException, HopsSecurityException {
+    try {
+      String projectName = hdfsUsersController.getProjectName(projectUsername);
+      String username = hdfsUsersController.getUserName(projectUsername);
+  
+      ProjectDTO projectDTO = projectController.getProjectByName(projectName);
+      Users user = userFacade.findByUsername(username);
+      if (user == null) {
+        throw new UserException(RESTCodes.UserErrorCode.USER_DOES_NOT_EXIST, Level.FINE);
+      }
+  
+      try {
+        AccessCredentialsDTO credentialsDTO = projectController.credentials(projectDTO.getProjectId(), user);
+        return Response.ok(credentialsDTO).build();
+      } catch (DatasetException ex) {
+        throw new HopsSecurityException(RESTCodes.SecurityErrorCode.CERTIFICATE_NOT_FOUND, Level.FINE);
+      }
+    } catch (ArrayIndexOutOfBoundsException ex) {
+      throw new UserException(RESTCodes.UserErrorCode.USER_WAS_NOT_FOUND, Level.FINE,
+          "Invalid project user format for username: " + projectUsername);
+    }
+  }
+}

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/rest/application/config/ApplicationConfig.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/rest/application/config/ApplicationConfig.java
@@ -98,7 +98,9 @@ public class ApplicationConfig extends ResourceConfig {
     register(io.hops.hopsworks.api.admin.SystemAdminService.class);
     register(io.hops.hopsworks.api.admin.ProjectsAdmin.class);
     register(io.hops.hopsworks.api.admin.llap.LlapAdmin.class);
-    register(io.hops.hopsworks.api.admin.CertificateMaterializerAdmin.class);
+    register(io.hops.hopsworks.api.admin.security.CertificateMaterializerAdmin.class);
+    register(io.hops.hopsworks.api.admin.security.CredentialsResource.class);
+    register(io.hops.hopsworks.api.admin.security.X509Resource.class);
 
     register(org.glassfish.jersey.media.multipart.MultiPartFeature.class);
 


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1362

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature

* **What is the new behavior (if this is a feature change)?**
Endpoint for admin or agent user securely get users' x.509

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
