### PR TITLE
[HOPSWORKS-1424][featurestore] Handle upper/lower case for feature group names

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -369,6 +369,18 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["errorCode"] == 270038).to be true
         end
 
+        it "should not be able to add a cached offline featuregroup to the featurestore with an empty hive table name" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features: nil, featuregroup_name: "")
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270038).to be true
+        end
+
         it "should not be able to add a cached offline featuregroup to the featurestore with a hive table name containing upper case" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -329,11 +329,11 @@ describe "On #{ENV['OS']}" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id,
-            featuregroup_name: "duplicatedName")
+            featuregroup_name: "duplicatedname")
           parsed_json = JSON.parse(json_result)
           expect_status(201)
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id,
-            featuregroup_name: "duplicatedName")
+            featuregroup_name: "duplicatedname")
           parsed_json = JSON.parse(json_result)
           expect_status(400)
         end
@@ -361,6 +361,18 @@ describe "On #{ENV['OS']}" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features: nil, featuregroup_name: "TEST_!%$1--")
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270038).to be true
+        end
+
+        it "should not be able to add a cached offline featuregroup to the featurestore with a hive table name containing upper case" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features: nil, featuregroup_name: "TEST_featuregroup")
           parsed_json = JSON.parse(json_result)
           expect_status(400)
           expect(parsed_json.key?("errorCode")).to be true
@@ -505,6 +517,20 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["name"] == featuregroup_name).to be true
           expect(parsed_json["featuregroupType"] == "ON_DEMAND_FEATURE_GROUP").to be true
           expect(parsed_json["jdbcConnectorId"] == connector_id).to be true
+        end
+
+        it "should not be able to add an on-demand featuregroup to the featurestore with a name containing upper case letters" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          connector_id = get_jdbc_connector_id
+          json_result, featuregroup_name = create_on_demand_featuregroup(project.id, featurestore_id, connector_id,
+                                                                         name: "TEST_ondemand_fg")
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270038).to be true
         end
 
         it "should not be able to add an on-demand featuregroup to the featurestore without a SQL query" do
@@ -775,6 +801,20 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["name"] == training_dataset_name).to be true
           expect(parsed_json["trainingDatasetType"] == "HOPSFS_TRAINING_DATASET").to be true
           expect(parsed_json["hopsfsConnectorId"] == connector.id).to be true
+        end
+
+        it "should not be able to add a hopsfs training dataset to the featurestore with upper case characters" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          connector = get_hopsfs_training_datasets_connector(@project[:projectname])
+          training_dataset_name = "TEST_training_dataset"
+          json_result, training_dataset_name = create_hopsfs_training_dataset(project.id, featurestore_id, connector, name:training_dataset_name)
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270053).to be true
         end
 
         it "should not be able to add a hopsfs training dataset to the featurestore without specifying a data format" do

--- a/hopsworks-IT/src/test/ruby/spec/helpers/featurestore_helper.rb
+++ b/hopsworks-IT/src/test/ruby/spec/helpers/featurestore_helper.rb
@@ -185,11 +185,15 @@ module FeaturestoreHelper
     return json_result, s3_connector_name
   end
 
-  def create_on_demand_featuregroup(project_id, featurestore_id, jdbcconnectorId, query: nil)
+  def create_on_demand_featuregroup(project_id, featurestore_id, jdbcconnectorId, name: nil, query: nil)
     type = "onDemandFeaturegroupDTO"
     featuregroupType = "ON_DEMAND_FEATURE_GROUP"
     create_featuregroup_endpoint = "#{ENV['HOPSWORKS_API']}/project/" + project_id.to_s + "/featurestores/" + featurestore_id.to_s + "/featuregroups"
-    featuregroup_name = "featuregroup_#{random_id}"
+    if name == nil
+      featuregroup_name = "featuregroup_#{random_id}"
+    else
+      featuregroup_name = name
+    end
     if query == nil
       query = "SELECT * FROM test"
     end
@@ -377,11 +381,15 @@ module FeaturestoreHelper
     return json_result
   end
 
-  def create_hopsfs_training_dataset(project_id, featurestore_id, hopsfs_connector, data_format: nil)
+  def create_hopsfs_training_dataset(project_id, featurestore_id, hopsfs_connector, name:nil, data_format: nil)
     type = "hopsfsTrainingDatasetDTO"
     trainingDatasetType = "HOPSFS_TRAINING_DATASET"
     create_training_dataset_endpoint = "#{ENV['HOPSWORKS_API']}/project/" + project_id.to_s + "/featurestores/" + featurestore_id.to_s + "/trainingdatasets"
-    training_dataset_name = "training_dataset_#{random_id}"
+    if name == nil
+      training_dataset_name = "training_dataset_#{random_id}"
+    else
+      training_dataset_name = name
+    end
     if data_format == nil
       data_format = "tfrecords"
     end

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
@@ -32,7 +32,7 @@ public class FeaturestoreConstants {
   }
 
   public static final int FEATURESTORE_STATISTICS_MAX_CORRELATIONS= 50;
-  public static final String FEATURESTORE_REGEX = "^[a-zA-Z0-9_]+$";
+  public static final String FEATURESTORE_REGEX = "^[a-z0-9_]+$";
   public static final int STORAGE_CONNECTOR_NAME_MAX_LENGTH = 1000;
   public static final int STORAGE_CONNECTOR_DESCRIPTION_MAX_LENGTH = 1000;
   public static final int JDBC_STORAGE_CONNECTOR_CONNECTIONSTRING_MAX_LENGTH = 5000;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
@@ -22,6 +22,7 @@ import io.hops.hopsworks.common.featurestore.storageconnectors.FeaturestoreStora
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Constants for the Feature Store Service
@@ -32,7 +33,7 @@ public class FeaturestoreConstants {
   }
 
   public static final int FEATURESTORE_STATISTICS_MAX_CORRELATIONS= 50;
-  public static final String FEATURESTORE_REGEX = "^[a-z0-9_]+$";
+  public static final Pattern FEATURESTORE_REGEX = Pattern.compile("^[a-z0-9_]+$");
   public static final int STORAGE_CONNECTOR_NAME_MAX_LENGTH = 1000;
   public static final int STORAGE_CONNECTOR_DESCRIPTION_MAX_LENGTH = 1000;
   public static final int JDBC_STORAGE_CONNECTOR_CONNECTIONSTRING_MAX_LENGTH = 5000;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
@@ -598,16 +598,15 @@ public class CachedFeaturegroupController {
           + FeaturestoreConstants.CACHED_FEATUREGROUP_DESCRIPTION_MAX_LENGTH + " characters");
     }
     //Only need to verify the DDL when creating table from Scratch and not Syncing
-    if(!sync){
-      if(!cachedFeaturegroupDTO.getFeatures().stream().filter(f -> {
-        return (Strings.isNullOrEmpty(f.getName()) ||
-          !namePattern.matcher(f.getName()).matches() || f.getName().length()
+    if (!sync) {
+      if (!cachedFeaturegroupDTO.getFeatures().stream().filter(f -> {
+        return (!namePattern.matcher(f.getName()).matches() || f.getName().length()
           > FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH);
       }).collect(Collectors.toList()).isEmpty()) {
         throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_NAME, Level.FINE,
           ", the feature name in a cached feature group should be less than "
             + FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH + " characters and match " +
-            "the regular expression: " +  FeaturestoreConstants.FEATURESTORE_REGEX);
+            "the regular expression: " + FeaturestoreConstants.FEATURESTORE_REGEX);
       }
   
       if(!cachedFeaturegroupDTO.getFeatures().stream().filter(f -> {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
@@ -580,7 +580,7 @@ public class CachedFeaturegroupController {
   public void verifyCachedFeaturegroupUserInput(CachedFeaturegroupDTO cachedFeaturegroupDTO, Boolean sync)
     throws FeaturestoreException {
 
-    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+    Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
 
     if(cachedFeaturegroupDTO.getName().length() > FeaturestoreConstants.CACHED_FEATUREGROUP_NAME_MAX_LENGTH ||
         !namePattern.matcher(cachedFeaturegroupDTO.getName()).matches()) {

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/ondemand/OnDemandFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/ondemand/OnDemandFeaturegroupController.java
@@ -125,10 +125,6 @@ public class OnDemandFeaturegroupController {
    */
   public void verifyOnDemandFeaturegroupName(String name) throws FeaturestoreException {
     Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
-    if(Strings.isNullOrEmpty(name)){
-      throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_NAME, Level.FINE,
-        ", the name of an on-demand feature group should not be empty ");
-    }
     if(name.length() > FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH  ||
       !namePattern.matcher(name).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_NAME, Level.FINE,
@@ -162,13 +158,15 @@ public class OnDemandFeaturegroupController {
    */
   private void verifyOnDemandFeaturegroupFeatures(List<FeatureDTO> featureDTOs) throws FeaturestoreException {
     if(featureDTOs != null && !featureDTOs.isEmpty()) {
+      Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
       if(!featureDTOs.stream().filter(f -> {
-        return (Strings.isNullOrEmpty(f.getName()) || f.getName().length() >
+        return (!namePattern.matcher(f.getName()).matches() || f.getName().length() >
           FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH);
       }).collect(Collectors.toList()).isEmpty()){
         throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_NAME, Level.FINE,
           ", the feature name in an on-demand feature group should be less than "
-            + FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH + " characters");
+            + FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH + " characters and match " +
+            "the regular expression: " + FeaturestoreConstants.FEATURESTORE_REGEX);
       }
       if(!featureDTOs.stream().filter(f -> {
         return (!Strings.isNullOrEmpty(f.getDescription()) &&

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/ondemand/OnDemandFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/ondemand/OnDemandFeaturegroupController.java
@@ -124,7 +124,7 @@ public class OnDemandFeaturegroupController {
    * @throws FeaturestoreException
    */
   public void verifyOnDemandFeaturegroupName(String name) throws FeaturestoreException {
-    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+    Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
     if(name.length() > FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH  ||
       !namePattern.matcher(name).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_NAME, Level.FINE,
@@ -158,7 +158,7 @@ public class OnDemandFeaturegroupController {
    */
   private void verifyOnDemandFeaturegroupFeatures(List<FeatureDTO> featureDTOs) throws FeaturestoreException {
     if(featureDTOs != null && !featureDTOs.isEmpty()) {
-      Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+      Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
       if(!featureDTOs.stream().filter(f -> {
         return (!namePattern.matcher(f.getName()).matches() || f.getName().length() >
           FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/ondemand/OnDemandFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/ondemand/OnDemandFeaturegroupController.java
@@ -32,6 +32,7 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -123,15 +124,17 @@ public class OnDemandFeaturegroupController {
    * @throws FeaturestoreException
    */
   public void verifyOnDemandFeaturegroupName(String name) throws FeaturestoreException {
+    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
     if(Strings.isNullOrEmpty(name)){
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_NAME, Level.FINE,
         ", the name of an on-demand feature group should not be empty ");
     }
-    if(name.length() >
-      FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH) {
+    if(name.length() > FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH  ||
+      !namePattern.matcher(name).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_NAME, Level.FINE,
         ", the name of an on-demand feature group should be less than "
-        + FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH + " characters");
+        + FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH + " characters and match " +
+          "the regular expression: " + FeaturestoreConstants.FEATURESTORE_REGEX);
     }
   }
   

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/settings/FeaturestoreClientSettingsDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/settings/FeaturestoreClientSettingsDTO.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class FeaturestoreClientSettingsDTO {
   
   private int featurestoreStatisticsMaxCorrelations = FeaturestoreConstants.FEATURESTORE_STATISTICS_MAX_CORRELATIONS;
-  private String featurestoreRegex = FeaturestoreConstants.FEATURESTORE_REGEX;
+  private String featurestoreRegex = FeaturestoreConstants.FEATURESTORE_REGEX.toString();
   private int storageConnectorNameMaxLength = FeaturestoreConstants.STORAGE_CONNECTOR_NAME_MAX_LENGTH;
   private int storageConnectorDescriptionMaxLength =
     FeaturestoreConstants.STORAGE_CONNECTOR_DESCRIPTION_MAX_LENGTH;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/external/ExternalTrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/external/ExternalTrainingDatasetController.java
@@ -84,7 +84,7 @@ public class ExternalTrainingDatasetController {
    * @throws FeaturestoreException
    */
   private void verifyExternalTrainingDatasetName(String name) throws FeaturestoreException {
-    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+    Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
     if (name.length() > FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH ||
       !namePattern.matcher(name).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/external/ExternalTrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/external/ExternalTrainingDatasetController.java
@@ -85,10 +85,6 @@ public class ExternalTrainingDatasetController {
    */
   private void verifyExternalTrainingDatasetName(String name) throws FeaturestoreException {
     Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
-    if (Strings.isNullOrEmpty(name)) {
-      throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,
-        ", the name of an external training dataset should not be empty ");
-    }
     if (name.length() > FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH ||
       !namePattern.matcher(name).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/external/ExternalTrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/external/ExternalTrainingDatasetController.java
@@ -30,6 +30,7 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 /**
  * Class controlling the interaction with the external_training_dataset table and required business logic
@@ -83,17 +84,18 @@ public class ExternalTrainingDatasetController {
    * @throws FeaturestoreException
    */
   private void verifyExternalTrainingDatasetName(String name) throws FeaturestoreException {
-    if(Strings.isNullOrEmpty(name)){
+    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+    if (Strings.isNullOrEmpty(name)) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,
         ", the name of an external training dataset should not be empty ");
     }
-    if(name.length() >
-      FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH) {
+    if (name.length() > FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH ||
+      !namePattern.matcher(name).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,
         ", the name of an external training dataset should be less than "
-        + FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH + " characters");
+          + FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH + " characters and match " +
+          "the regular expression: " + FeaturestoreConstants.FEATURESTORE_REGEX);
     }
-    
   }
   
   /**

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/hopsfs/HopsfsTrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/hopsfs/HopsfsTrainingDatasetController.java
@@ -106,7 +106,7 @@ public class HopsfsTrainingDatasetController {
    * @throws FeaturestoreException
    */
   private void verifyHopsfsTrainingDatasetName(String hopsfsTrainingDatasetName) throws FeaturestoreException {
-    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+    Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
     if (hopsfsTrainingDatasetName.length() > FeaturestoreConstants.HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH ||
       !namePattern.matcher(hopsfsTrainingDatasetName).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/hopsfs/HopsfsTrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/hopsfs/HopsfsTrainingDatasetController.java
@@ -32,6 +32,7 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 /**
  * Class controlling the interaction with the hopsfs_training_dataset table and required business logic
@@ -105,11 +106,13 @@ public class HopsfsTrainingDatasetController {
    * @throws FeaturestoreException
    */
   private void verifyHopsfsTrainingDatasetName(String hopsfsTrainingDatasetName) throws FeaturestoreException {
-    if(hopsfsTrainingDatasetName.length() >
-      FeaturestoreConstants.HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH) {
+    Pattern namePattern = Pattern.compile(FeaturestoreConstants.FEATURESTORE_REGEX);
+    if (hopsfsTrainingDatasetName.length() > FeaturestoreConstants.HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH ||
+      !namePattern.matcher(hopsfsTrainingDatasetName).matches()) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_TRAINING_DATASET_NAME, Level.FINE,
-        ", the name of a hopsfs training dataset should be less than "
-          + FeaturestoreConstants.HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH + " characters");
+        ", the name of a hopsfs training dataset should be less than " +
+          FeaturestoreConstants.HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH + " characters and match " +
+          "the regular expression: " + FeaturestoreConstants.FEATURESTORE_REGEX);
     }
   }
 

--- a/hopsworks-web/yo/app/scripts/controllers/newTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/newTrainingDatasetCtrl.js
@@ -69,6 +69,7 @@ angular.module('hopsWorksApp')
             //Constants
             self.trainingDatasetNameMaxLength = self.settings.hopsfsTrainingDatasetNameMaxLength
             self.trainingDatasetDescriptionMaxLength = self.settings.trainingDatasetDescriptionMaxLength
+            self.trainingDatasetNameRegexp = self.settings.featurestoreRegex
             self.dataFormats = self.settings.trainingDatasetDataFormats
             self.hopsfsTrainingDatasetType = self.settings.hopsfsTrainingDatasetType
             self.hopsfsTrainingDatasetTypeDTO = self.settings.hopsfsTrainingDatasetDtoType

--- a/hopsworks-web/yo/app/views/newFeaturegroup.html
+++ b/hopsworks-web/yo/app/views/newFeaturegroup.html
@@ -85,11 +85,10 @@
                                         ng-if="newFeaturegroupCtrl.cachedFeaturegroupNameWrongValue === -1"
                                         style="color: red">
                                     <p>
-                                        Feature Group Name shouldn't be empty and can only contain alphanumeric
-                                        characters and underscores,
+                                        Feature Group Name shouldn't be empty and can only contain lower
+                                        case, alphanumeric characters and underscores,
                                         maximum length is {{newFeaturegroupCtrl.cachedFeaturegroupNameMaxLength}}
-                                        characters.
-                                        Hyphens are not allowed in the name.
+                                        characters. Hyphens are not allowed in the name.
                                     </p>
                                 </div>
                             </div>

--- a/hopsworks-web/yo/app/views/newTrainingDataset.html
+++ b/hopsworks-web/yo/app/views/newTrainingDataset.html
@@ -411,9 +411,8 @@
                                     ng-if="newTrainingDatasetCtrl.trainingDatasetNameWrongValue === -1"
                                     style="color: red">
                                 <p>
-                                    Training dataset name shouldn't be empty and can only contain alphanumeric
-                                    characters and
-                                    underscores, maximum length is
+                                    Training dataset name shouldn't be empty and can only contain lower case
+                                    alphanumeric characters and underscores, maximum length is
                                     {{newTrainingDatasetCtrl.trainingDatasetDescriptionMaxLength}}
                                     characters. Hyphens are not allowed in the training dataset name.
                                 </p>


### PR DESCRIPTION

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1424

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
These changes prevent the user of using Upper case characters in featurestore entity names. Instead of silently lower casing everything, which lead to problems when a user tries to get an entity with a name containing upper case letters.

Ran the featurestore tests locally, and they passed

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
