### PR TITLE
[HOPSWORKS-1461] The JWT signing key should be decoded first before u…

### DIFF
--- a/hopsworks-jwt/src/main/java/io/hops/hopsworks/jwt/AlgorithmFactory.java
+++ b/hopsworks-jwt/src/main/java/io/hops/hopsworks/jwt/AlgorithmFactory.java
@@ -26,6 +26,7 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.ws.rs.NotSupportedException;
@@ -89,7 +90,7 @@ public class AlgorithmFactory {
     return Algorithm.ECDSA512(keyProvider);
   }
 
-  private String getSigningKey(String keyId) throws SigningKeyNotFoundException {
+  private byte[] getSigningKey(String keyId) throws SigningKeyNotFoundException {
     Integer id;
     try {
       id = Integer.parseInt(keyId);
@@ -100,7 +101,7 @@ public class AlgorithmFactory {
     if (signingKey == null) {
       throw new SigningKeyNotFoundException("Signing key not found.");
     }
-    return signingKey.getSecret();
+    return Base64.getDecoder().decode(signingKey.getSecret());
   }
 
   private Algorithm getHS256Algorithm(String keyId) throws SigningKeyNotFoundException {


### PR DESCRIPTION
…sing it to sign jwt

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1461

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
tests: https://github.com/logicalclocks/hops-testing/pull/560