### PR TITLE
[HOPSWORKS-1435][featurestore] Unify feature store entity max length validation in backend

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -451,7 +451,7 @@ describe "On #{ENV['OS']}" do
           parsed_json = JSON.parse(json_result)
           expect_status(201)
           expect(parsed_json["features"].length).to be 1
-          expect(parsed_json["features"].first["description"]).to be ""
+          expect(parsed_json["features"].first["description"] == "").to be true
         end
 
         it "should be able to preview a offline cached featuregroup in the featurestore" do

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -393,7 +393,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["errorCode"] == 270091).to be true
         end
 
-        it "should not be able to add a offline cached featuregroup to the featurestore with invalid hive schema" do
+        it "should not be able to add a offline cached featuregroup to the featurestore with invalid feature name" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           features = [
@@ -401,7 +401,7 @@ describe "On #{ENV['OS']}" do
                   type: "test",
                   name: "--",
                   description: "--",
-                  primary: false
+                  primary: true
               }
           ]
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)
@@ -412,6 +412,26 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["errorCode"] == 270040).to be true
         end
 
+        it "should not be able to add a offline cached featuregroup to the featurestore with invalid hive schema" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          features = [
+              {
+                  type: "test",
+                  name: "test",
+                  description: "--",
+                  primary: false
+              }
+          ]
+          json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)
+          parsed_json = JSON.parse(json_result)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270017).to be true
+        end
+
+
         it "should be able to add a offline cached featuregroup to the featurestore with empty feature description" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
@@ -420,7 +440,7 @@ describe "On #{ENV['OS']}" do
                   type: "test",
                   name: "test_feat_no_description",
                   description: "",
-                  primary: false
+                  primary: true
               }
           ]
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -451,7 +451,7 @@ describe "On #{ENV['OS']}" do
           parsed_json = JSON.parse(json_result)
           expect_status(201)
           expect(parsed_json["features"].length).to be 1
-          expect(parsed_json["features"].first["description"] == "").to be true
+          expect(parsed_json["features"].first["description"]).to be ""
         end
 
         it "should be able to preview a offline cached featuregroup in the featurestore" do

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -369,6 +369,19 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["errorCode"] == 270091).to be true
         end
 
+        it "should not be able to add a cached offline featuregroup to the featurestore with a number only hive table name" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features: nil,
+                                                                      featuregroup_name: "1111")
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
+        end
+
         it "should not be able to add a cached offline featuregroup to the featurestore with an empty hive table name" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -397,10 +397,12 @@ describe "On #{ENV['OS']}" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           features = [
-              type: "test",
-              name: "--",
-              description: "--",
-              primary: false
+              {
+                  type: "test",
+                  name: "--",
+                  description: "--",
+                  primary: false
+              }
           ]
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)
           parsed_json = JSON.parse(json_result)
@@ -414,10 +416,12 @@ describe "On #{ENV['OS']}" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           features = [
-              type: "test",
-              name: "test_feat_no_description",
-              description: "",
-              primary: false
+              {
+                  type: "test",
+                  name: "test_feat_no_description",
+                  description: "",
+                  primary: false
+              }
           ]
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)
           parsed_json = JSON.parse(json_result)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -406,6 +406,19 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["errorCode"] == 270091).to be true
         end
 
+        it "should not be able to add a cached offline featuregroup to the featurestore with a too long hive table name" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features: nil,
+                                                                      featuregroup_name: "a"*65)
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
+        end
+
         it "should not be able to add a offline cached featuregroup to the featurestore with invalid feature name" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -366,7 +366,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json.key?("errorCode")).to be true
           expect(parsed_json.key?("errorMsg")).to be true
           expect(parsed_json.key?("usrMsg")).to be true
-          expect(parsed_json["errorCode"] == 270038).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
         end
 
         it "should not be able to add a cached offline featuregroup to the featurestore with an empty hive table name" do
@@ -378,7 +378,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json.key?("errorCode")).to be true
           expect(parsed_json.key?("errorMsg")).to be true
           expect(parsed_json.key?("usrMsg")).to be true
-          expect(parsed_json["errorCode"] == 270038).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
         end
 
         it "should not be able to add a cached offline featuregroup to the featurestore with a hive table name containing upper case" do
@@ -390,7 +390,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json.key?("errorCode")).to be true
           expect(parsed_json.key?("errorMsg")).to be true
           expect(parsed_json.key?("usrMsg")).to be true
-          expect(parsed_json["errorCode"] == 270038).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
         end
 
         it "should not be able to add a offline cached featuregroup to the featurestore with invalid hive schema" do
@@ -463,7 +463,7 @@ describe "On #{ENV['OS']}" do
           expect_status(200)
         end
 
-        it "should be able to update the metadata of a cached featuregroup from the featurestore" do
+        it "should not be able to update the metadata of a cached featuregroup from the featurestore" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id)
@@ -471,8 +471,14 @@ describe "On #{ENV['OS']}" do
           expect_status(201)
           featuregroup_id = parsed_json["id"]
           featuregroup_version = parsed_json["version"]
-          update_cached_featuregroup_metadata(project.id, featurestore_id, featuregroup_id, featuregroup_version)
-          expect_status(200)
+          json_result = update_cached_featuregroup_metadata(project.id, featurestore_id, featuregroup_id,
+                                                          featuregroup_version)
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270093).to be true
         end
 
         it "should be able to update the statistics settings of a cached featuregroup" do
@@ -542,7 +548,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json.key?("errorCode")).to be true
           expect(parsed_json.key?("errorMsg")).to be true
           expect(parsed_json.key?("usrMsg")).to be true
-          expect(parsed_json["errorCode"] == 270038).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
         end
 
         it "should not be able to add an on-demand featuregroup to the featurestore without a SQL query" do
@@ -722,7 +728,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["id"] == featuregroup_id).to be true
         end
 
-        it "should be able to update the metadata of a cached online featuregroup from the featurestore" do
+        it "should not be able to update the metadata of a cached online featuregroup from the featurestore" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, online:true)
@@ -730,8 +736,15 @@ describe "On #{ENV['OS']}" do
           expect_status(201)
           featuregroup_id = parsed_json["id"]
           featuregroup_version = parsed_json["version"]
-          update_cached_featuregroup_metadata(project.id, featurestore_id, featuregroup_id, featuregroup_version)
-          expect_status(200)
+          json_result = update_cached_featuregroup_metadata(project.id, featurestore_id, featuregroup_id,
+                                                      featuregroup_version)
+          parsed_json = JSON.parse(json_result)
+
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270093).to be true
         end
 
         it "should be able to enable online serving for a offline cached feature group" do
@@ -826,7 +839,7 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json.key?("errorCode")).to be true
           expect(parsed_json.key?("errorMsg")).to be true
           expect(parsed_json.key?("usrMsg")).to be true
-          expect(parsed_json["errorCode"] == 270053).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
         end
 
         it "should not be able to add a hopsfs training dataset to the featurestore without specifying a data format" do
@@ -937,6 +950,21 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["name"] == training_dataset_name).to be true
           expect(parsed_json["trainingDatasetType"] == "EXTERNAL_TRAINING_DATASET").to be true
           expect(parsed_json["s3ConnectorId"] == connector_id).to be true
+        end
+
+        it "should not be able to add an external training dataset to the featurestore with upper case characters" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          connector_id = get_s3_connector_id
+          training_dataset_name = "TEST_training_dataset"
+          json_result, training_dataset_name = create_external_training_dataset(project.id, featurestore_id, connector_id,
+                                                                         name:training_dataset_name)
+          parsed_json = JSON.parse(json_result)
+          expect_status(400)
+          expect(parsed_json.key?("errorCode")).to be true
+          expect(parsed_json.key?("errorMsg")).to be true
+          expect(parsed_json.key?("usrMsg")).to be true
+          expect(parsed_json["errorCode"] == 270091).to be true
         end
 
         it "should not be able to add an external training dataset to the featurestore without specifying a s3 connector" do

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -439,10 +439,12 @@ describe "On #{ENV['OS']}" do
           featurestore_id = get_featurestore_id(project.id)
           features = [
               {
-                  type: "test",
+                  type: "INT",
                   name: "test_feat_no_description",
                   description: "",
-                  primary: true
+                  primary: true,
+                  onlineType: nil,
+                  partition: false
               }
           ]
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -398,10 +398,12 @@ describe "On #{ENV['OS']}" do
           featurestore_id = get_featurestore_id(project.id)
           features = [
               {
-                  type: "test",
+                  type: "INT",
                   name: "--",
                   description: "--",
-                  primary: true
+                  primary: true,
+                  onlineType: nil,
+                  partition: false
               }
           ]
           json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)

--- a/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featurestore_spec.rb
@@ -410,6 +410,22 @@ describe "On #{ENV['OS']}" do
           expect(parsed_json["errorCode"] == 270040).to be true
         end
 
+        it "should be able to add a offline cached featuregroup to the featurestore with empty feature description" do
+          project = get_project
+          featurestore_id = get_featurestore_id(project.id)
+          features = [
+              type: "test",
+              name: "test_feat_no_description",
+              description: "",
+              primary: false
+          ]
+          json_result, featuregroup_name = create_cached_featuregroup(project.id, featurestore_id, features:features)
+          parsed_json = JSON.parse(json_result)
+          expect_status(201)
+          expect(parsed_json["features"].length).to be 1
+          expect(parsed_json["features"].first["description"] == "").to be true
+        end
+
         it "should be able to preview a offline cached featuregroup in the featurestore" do
           project = get_project
           featurestore_id = get_featurestore_id(project.id)

--- a/hopsworks-IT/src/test/ruby/spec/helpers/featurestore_helper.rb
+++ b/hopsworks-IT/src/test/ruby/spec/helpers/featurestore_helper.rb
@@ -416,11 +416,15 @@ module FeaturestoreHelper
     return json_result, training_dataset_name
   end
 
-  def create_external_training_dataset(project_id, featurestore_id, s3_connector_id)
+  def create_external_training_dataset(project_id, featurestore_id, s3_connector_id, name: nil)
     type = "externalTrainingDatasetDTO"
     trainingDatasetType = "EXTERNAL_TRAINING_DATASET"
     create_training_dataset_endpoint = "#{ENV['HOPSWORKS_API']}/project/" + project_id.to_s + "/featurestores/" + featurestore_id.to_s + "/trainingdatasets"
-    training_dataset_name = "training_dataset_#{random_id}"
+    if name == nil
+      training_dataset_name = "training_dataset_#{random_id}"
+    else
+      training_dataset_name = name
+    end
     json_data = {
         name: training_dataset_name,
         jobs: [],

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
@@ -47,12 +47,6 @@ public class FeaturestoreConstants {
   public static final int ON_DEMAND_FEATUREGROUP_SQL_QUERY_MAX_LENGTH = 11000;
   public static final List<String> TRAINING_DATASET_DATA_FORMATS = Arrays.asList(new String[]{"csv", "tfrecords",
     "parquet", "tsv", "hdf5", "npy", "orc", "avro", "image", "petastorm"});
-  //-
-  public static final int EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH = 256;
-  public static final int HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH = 256;
-  public static final int TRAINING_DATASET_FEATURE_NAME_MAX_LENGTH = 1000;
-  public static final int TRAINING_DATASET_FEATURE_DESCRIPTION_MAX_LENGTH = 10000;
-  //
   public static final String ON_DEMAND_FEATUREGROUP_TYPE = FeaturegroupType.ON_DEMAND_FEATURE_GROUP.name();
   public static final String CACHED_FEATUREGROUP_TYPE = FeaturegroupType.CACHED_FEATURE_GROUP.name();
   public static final String JDBC_CONNECTOR_TYPE = FeaturestoreStorageConnectorType.JDBC.name();
@@ -64,9 +58,6 @@ public class FeaturestoreConstants {
   public static final String EXTERNAL_TRAINING_DATASET_TYPE = TrainingDatasetType.EXTERNAL_TRAINING_DATASET.name();
   public static final String HOPSFS_TRAINING_DATASET_DTO_TYPE = "hopsfsTrainingDatasetDTO";
   public static final String EXTERNAL_TRAINING_DATASET_DTO_TYPE = "externalTrainingDatasetDTO";
-  //-
-  public static final int TRAINING_DATASET_DESCRIPTION_MAX_LENGTH = 10000;
-  //
   public static final String S3_CONNECTOR_DTO_TYPE = "featurestoreS3ConnectorDTO";
   public static final String JDBC_CONNECTOR_DTO_TYPE = "featurestoreJdbcConnectorDTO";
   public static final String HOPSFS_CONNECTOR_DTO_TYPE = "featurestoreHopsfsConnectorDTO";

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
@@ -33,7 +33,7 @@ public class FeaturestoreConstants {
   }
 
   public static final int FEATURESTORE_STATISTICS_MAX_CORRELATIONS= 50;
-  public static final Pattern FEATURESTORE_REGEX = Pattern.compile("^[a-z0-9_]{1,63}$");
+  public static final Pattern FEATURESTORE_REGEX = Pattern.compile("^(?=.{1,63}$)([a-z0-9_]*[a-z]{1}[a-z0-9_]*)$");
   public static final int FEATURESTORE_ENTITY_NAME_MAX_LENGTH = 63; // limited by NDB due to online fg
   public static final int FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH = 256; // can possibly 1000, but the one for
   // features is limited to 256

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/FeaturestoreConstants.java
@@ -33,7 +33,10 @@ public class FeaturestoreConstants {
   }
 
   public static final int FEATURESTORE_STATISTICS_MAX_CORRELATIONS= 50;
-  public static final Pattern FEATURESTORE_REGEX = Pattern.compile("^[a-z0-9_]+$");
+  public static final Pattern FEATURESTORE_REGEX = Pattern.compile("^[a-z0-9_]{1,63}$");
+  public static final int FEATURESTORE_ENTITY_NAME_MAX_LENGTH = 63; // limited by NDB due to online fg
+  public static final int FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH = 256; // can possibly 1000, but the one for
+  // features is limited to 256
   public static final int STORAGE_CONNECTOR_NAME_MAX_LENGTH = 1000;
   public static final int STORAGE_CONNECTOR_DESCRIPTION_MAX_LENGTH = 1000;
   public static final int JDBC_STORAGE_CONNECTOR_CONNECTIONSTRING_MAX_LENGTH = 5000;
@@ -41,21 +44,15 @@ public class FeaturestoreConstants {
   public static final int S3_STORAGE_CONNECTOR_BUCKET_MAX_LENGTH = 5000;
   public static final int S3_STORAGE_CONNECTOR_ACCESSKEY_MAX_LENGTH = 1000;
   public static final int S3_STORAGE_CONNECTOR_SECRETKEY_MAX_LENGTH = 1000;
-  public static final int CACHED_FEATUREGROUP_NAME_MAX_LENGTH = 767;
-  public static final int CACHED_FEATUREGROUP_DESCRIPTION_MAX_LENGTH = 256;
-  public static final int CACHED_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH = 767;
-  public static final int CACHED_FEATUREGROUP_FEATURE_DESCRIPTION_MAX_LENGTH = 256;
-  public static final int ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH = 1000;
-  public static final int ON_DEMAND_FEATUREGROUP_DESCRIPTION_MAX_LENGTH = 1000;
-  public static final int ON_DEMAND_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH = 1000;
-  public static final int ON_DEMAND_FEATUREGROUP_FEATURE_DESCRIPTION_MAX_LENGTH = 10000;
   public static final int ON_DEMAND_FEATUREGROUP_SQL_QUERY_MAX_LENGTH = 11000;
   public static final List<String> TRAINING_DATASET_DATA_FORMATS = Arrays.asList(new String[]{"csv", "tfrecords",
     "parquet", "tsv", "hdf5", "npy", "orc", "avro", "image", "petastorm"});
+  //-
   public static final int EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH = 256;
   public static final int HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH = 256;
   public static final int TRAINING_DATASET_FEATURE_NAME_MAX_LENGTH = 1000;
   public static final int TRAINING_DATASET_FEATURE_DESCRIPTION_MAX_LENGTH = 10000;
+  //
   public static final String ON_DEMAND_FEATUREGROUP_TYPE = FeaturegroupType.ON_DEMAND_FEATURE_GROUP.name();
   public static final String CACHED_FEATUREGROUP_TYPE = FeaturegroupType.CACHED_FEATURE_GROUP.name();
   public static final String JDBC_CONNECTOR_TYPE = FeaturestoreStorageConnectorType.JDBC.name();
@@ -67,7 +64,9 @@ public class FeaturestoreConstants {
   public static final String EXTERNAL_TRAINING_DATASET_TYPE = TrainingDatasetType.EXTERNAL_TRAINING_DATASET.name();
   public static final String HOPSFS_TRAINING_DATASET_DTO_TYPE = "hopsfsTrainingDatasetDTO";
   public static final String EXTERNAL_TRAINING_DATASET_DTO_TYPE = "externalTrainingDatasetDTO";
+  //-
   public static final int TRAINING_DATASET_DESCRIPTION_MAX_LENGTH = 10000;
+  //
   public static final String S3_CONNECTOR_DTO_TYPE = "featurestoreS3ConnectorDTO";
   public static final String JDBC_CONNECTOR_DTO_TYPE = "featurestoreJdbcConnectorDTO";
   public static final String HOPSFS_CONNECTOR_DTO_TYPE = "featurestoreHopsfsConnectorDTO";

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/FeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/FeaturegroupController.java
@@ -148,7 +148,7 @@ public class FeaturegroupController {
     throws FeaturestoreException, HopsSecurityException, SQLException, ProvenanceException {
 
     // Verify general entity related information
-    featurestoreInputValidation.verifyUserInput(featuregroupDTO, false);
+    featurestoreInputValidation.verifyUserInput(featuregroupDTO);
 
     //Verify feature group input type
     verifyFeaturegroupType(featuregroupDTO, featurestore);
@@ -279,7 +279,7 @@ public class FeaturegroupController {
     }
 
     // Verify general entity related information
-    featurestoreInputValidation.verifyUserInput(featuregroupDTO, false);
+    featurestoreInputValidation.verifyUserInput(featuregroupDTO);
 
     //Verify feature group input type
     verifyFeaturegroupType(featuregroupDTO, featurestore);
@@ -642,7 +642,7 @@ public class FeaturegroupController {
     Users user) throws FeaturestoreException {
   
     // Verify general entity related information
-    featurestoreInputValidation.verifyUserInput(featuregroupDTO, false);
+    featurestoreInputValidation.verifyUserInput(featuregroupDTO);
   
     //Verify feature group input type
     verifyFeaturegroupType(featuregroupDTO, featurestore);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/FeaturegroupDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/FeaturegroupDTO.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CachedFeaturegroupDTO.class, name = "OnlineFeaturegroupDTO"),
-    @JsonSubTypes.Type(value = OnDemandFeaturegroupDTO.class, name = "HopsfsTrainingDatasetDTO")})
+    @JsonSubTypes.Type(value = OnDemandFeaturegroupDTO.class, name = "OnDemandFeaturegroupDTO")})
 public class FeaturegroupDTO extends FeaturestoreEntityDTO {
 
   private FeaturegroupType featuregroupType;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
@@ -621,7 +621,7 @@ public class CachedFeaturegroupController {
         } else {
           schemaStringBuilder.append(feature.getOnlineType());
         }
-        if (Strings.isNullOrEmpty(feature.getDescription())) {
+        if (!Strings.isNullOrEmpty(feature.getDescription())) {
           schemaStringBuilder.append(" COMMENT '");
           schemaStringBuilder.append(feature.getDescription());
           schemaStringBuilder.append("'");
@@ -641,7 +641,7 @@ public class CachedFeaturegroupController {
         } else {
           partitionStringBuilder.append(feature.getOnlineType());
         }
-        if (Strings.isNullOrEmpty(feature.getDescription())) {
+        if (!Strings.isNullOrEmpty(feature.getDescription())) {
           partitionStringBuilder.append(" COMMENT '");
           partitionStringBuilder.append(feature.getDescription());
           partitionStringBuilder.append("'");

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
@@ -16,7 +16,6 @@
 
 package io.hops.hopsworks.common.featurestore.featuregroup.cached;
 
-import com.google.common.base.Strings;
 import io.hops.hopsworks.common.dao.featurestore.Featurestore;
 import io.hops.hopsworks.common.dao.featurestore.featuregroup.Featuregroup;
 import io.hops.hopsworks.common.dao.featurestore.featuregroup.cached.CachedFeaturegroup;
@@ -30,7 +29,7 @@ import io.hops.hopsworks.common.featurestore.online.OnlineFeaturestoreController
 import io.hops.hopsworks.common.provenance.core.HopsFSProvenanceController;
 import io.hops.hopsworks.common.dao.project.Project;
 import io.hops.hopsworks.common.dao.user.Users;
-import io.hops.hopsworks.common.featurestore.FeaturestoreConstants;
+import io.hops.hopsworks.common.featurestore.utils.FeaturestoreInputValidation;
 import io.hops.hopsworks.common.hive.HiveTableType;
 import io.hops.hopsworks.common.security.CertificateMaterializer;
 import io.hops.hopsworks.common.util.Settings;
@@ -58,7 +57,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -80,6 +78,8 @@ public class CachedFeaturegroupController {
   private OnlineFeaturestoreController onlineFeaturestoreController;
   @EJB
   private HopsFSProvenanceController fsController;
+  @EJB
+  private FeaturestoreInputValidation featurestoreInputValidation;
 
   private static final Logger LOGGER = Logger.getLogger(CachedFeaturegroupController.class.getName());
   private static final String HIVE_DRIVER = "org.apache.hive.jdbc.HiveDriver";
@@ -263,9 +263,7 @@ public class CachedFeaturegroupController {
   public CachedFeaturegroup createCachedFeaturegroup(
       Featurestore featurestore, CachedFeaturegroupDTO cachedFeaturegroupDTO, Users user)
     throws FeaturestoreException, HopsSecurityException, SQLException, ProvenanceException {
-    //Verify User Input
-    verifyCachedFeaturegroupUserInput(cachedFeaturegroupDTO, false);
-    
+
     //Prepare DDL statement
     String hiveFeatureStr = makeCreateTableColumnsStr(cachedFeaturegroupDTO.getFeatures(),
       cachedFeaturegroupDTO.getDescription(), false);
@@ -575,59 +573,6 @@ public class CachedFeaturegroupController {
   }
 
   /**
-   * Verify user input specific for creation of on-demand training dataset
-   *
-   * @param cachedFeaturegroupDTO the user input data for creating the feature group
-   * @throws FeaturestoreException
-   */
-  @TransactionAttribute(TransactionAttributeType.NEVER)
-  public void verifyCachedFeaturegroupUserInput(CachedFeaturegroupDTO cachedFeaturegroupDTO, Boolean sync)
-    throws FeaturestoreException {
-
-    Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
-
-    if(cachedFeaturegroupDTO.getName().length() > FeaturestoreConstants.CACHED_FEATUREGROUP_NAME_MAX_LENGTH ||
-        !namePattern.matcher(cachedFeaturegroupDTO.getName()).matches()) {
-      throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_NAME, Level.FINE,
-          ", the name of a cached feature group should be less than "
-          + FeaturestoreConstants.CACHED_FEATUREGROUP_NAME_MAX_LENGTH + " characters and match " +
-          "the regular expression: " +  FeaturestoreConstants.FEATURESTORE_REGEX);
-    }
-
-    if(!Strings.isNullOrEmpty(cachedFeaturegroupDTO.getDescription()) &&
-        cachedFeaturegroupDTO.getDescription().length() >
-          FeaturestoreConstants.CACHED_FEATUREGROUP_DESCRIPTION_MAX_LENGTH){
-      throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATUREGROUP_DESCRIPTION, Level.FINE,
-          ", the descritpion of a cached feature group should be less than "
-          + FeaturestoreConstants.CACHED_FEATUREGROUP_DESCRIPTION_MAX_LENGTH + " characters");
-    }
-    //Only need to verify the DDL when creating table from Scratch and not Syncing
-    if (!sync) {
-      if (!cachedFeaturegroupDTO.getFeatures().stream().filter(f -> {
-        return (!namePattern.matcher(f.getName()).matches() || f.getName().length()
-          > FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH);
-      }).collect(Collectors.toList()).isEmpty()) {
-        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_NAME, Level.FINE,
-          ", the feature name in a cached feature group should be less than "
-            + FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH + " characters and match " +
-            "the regular expression: " + FeaturestoreConstants.FEATURESTORE_REGEX);
-      }
-  
-      if(!cachedFeaturegroupDTO.getFeatures().stream().filter(f -> {
-        if(Strings.isNullOrEmpty(f.getDescription())){
-          f.setDescription("-");
-        }
-        return (f.getDescription().length() >
-          FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_DESCRIPTION_MAX_LENGTH);
-      }).collect(Collectors.toList()).isEmpty()) {
-        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_DESCRIPTION, Level.FINE,
-          ", the feature description in a cached feature group should be less than "
-            + FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_DESCRIPTION_MAX_LENGTH + " characters");
-      }
-    }
-  }
-
-  /**
    * Returns a String with Columns from a JSON featuregroup
    * that can be used for a HiveQL CREATE TABLE statement or MySQL
    *
@@ -738,8 +683,6 @@ public class CachedFeaturegroupController {
   @TransactionAttribute(TransactionAttributeType.NEVER)
   public CachedFeaturegroup syncHiveTableWithFeaturestore(Featurestore featurestore,
     CachedFeaturegroupDTO cachedFeaturegroupDTO) throws FeaturestoreException {
-    //Verify User Input
-    verifyCachedFeaturegroupUserInput(cachedFeaturegroupDTO, true);
   
     //Get Hive Table Metadata
     String tableName = getTblName(cachedFeaturegroupDTO.getName(), cachedFeaturegroupDTO.getVersion());

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupController.java
@@ -16,6 +16,7 @@
 
 package io.hops.hopsworks.common.featurestore.featuregroup.cached;
 
+import com.google.common.base.Strings;
 import io.hops.hopsworks.common.dao.featurestore.Featurestore;
 import io.hops.hopsworks.common.dao.featurestore.featuregroup.Featuregroup;
 import io.hops.hopsworks.common.dao.featurestore.featuregroup.cached.CachedFeaturegroup;
@@ -620,9 +621,11 @@ public class CachedFeaturegroupController {
         } else {
           schemaStringBuilder.append(feature.getOnlineType());
         }
-        schemaStringBuilder.append(" COMMENT '");
-        schemaStringBuilder.append(feature.getDescription());
-        schemaStringBuilder.append("'");
+        if (Strings.isNullOrEmpty(feature.getDescription())) {
+          schemaStringBuilder.append(" COMMENT '");
+          schemaStringBuilder.append(feature.getDescription());
+          schemaStringBuilder.append("'");
+        }
         schemaStringBuilder.append(", ");
       } else {
         if(!firstPartition){
@@ -638,9 +641,11 @@ public class CachedFeaturegroupController {
         } else {
           partitionStringBuilder.append(feature.getOnlineType());
         }
-        partitionStringBuilder.append(" COMMENT '");
-        partitionStringBuilder.append(feature.getDescription());
-        partitionStringBuilder.append("'");
+        if (Strings.isNullOrEmpty(feature.getDescription())) {
+          partitionStringBuilder.append(" COMMENT '");
+          partitionStringBuilder.append(feature.getDescription());
+          partitionStringBuilder.append("'");
+        }
       }
       if (i == features.size() - 1){
         Boolean firstPrimary = true;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupFacade.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/cached/CachedFeaturegroupFacade.java
@@ -79,7 +79,7 @@ public class CachedFeaturegroupFacade extends AbstractFacade<CachedFeaturegroup>
     ArrayList<FeatureDTO> featureDTOs = new ArrayList<>();
     for (Object[] featureObject : featureObjects) {
       FeatureDTO featureDTO = new FeatureDTO((String) featureObject[0], (String) featureObject[1],
-          (String) featureObject[2]);
+          featureObject[2] == null ? "": (String) featureObject[2]);
       featureDTOs.add(featureDTO);
     }
     featureDTOs.addAll(getHivePartitionKeys(hiveTableId));

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/settings/FeaturestoreClientSettingsDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/settings/FeaturestoreClientSettingsDTO.java
@@ -31,6 +31,10 @@ public class FeaturestoreClientSettingsDTO {
   
   private int featurestoreStatisticsMaxCorrelations = FeaturestoreConstants.FEATURESTORE_STATISTICS_MAX_CORRELATIONS;
   private String featurestoreRegex = FeaturestoreConstants.FEATURESTORE_REGEX.toString();
+  private int featurestoreEntityNameMaxLength = FeaturestoreConstants.FEATURESTORE_ENTITY_NAME_MAX_LENGTH;
+  private int featurestoreEntityDescriptionMaxLength = FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH;
+  private int onDemandFeaturegroupSqlQueryMaxLength =
+    FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_SQL_QUERY_MAX_LENGTH;
   private int storageConnectorNameMaxLength = FeaturestoreConstants.STORAGE_CONNECTOR_NAME_MAX_LENGTH;
   private int storageConnectorDescriptionMaxLength =
     FeaturestoreConstants.STORAGE_CONNECTOR_DESCRIPTION_MAX_LENGTH;
@@ -45,32 +49,7 @@ public class FeaturestoreClientSettingsDTO {
   private int s3StorageConnectorSecretkeyMaxLength =
     FeaturestoreConstants.S3_STORAGE_CONNECTOR_SECRETKEY_MAX_LENGTH;
   private boolean s3IAMRole = false;
-  private int cachedFeaturegroupNameMaxLength = FeaturestoreConstants.CACHED_FEATUREGROUP_NAME_MAX_LENGTH;
-  private int cachedFeaturegroupDescriptionMaxLength =
-    FeaturestoreConstants.CACHED_FEATUREGROUP_DESCRIPTION_MAX_LENGTH;
-  private int cachedFeaturegroupFeatureNameMaxLength =
-    FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH;
-  private int cachedFeaturegroupFeatureDescriptionMaxLength =
-    FeaturestoreConstants.CACHED_FEATUREGROUP_FEATURE_DESCRIPTION_MAX_LENGTH;
-  private int onDemandFeaturegroupNameMaxLength =
-    FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_NAME_MAX_LENGTH;
-  private int onDemandFeaturegroupDescriptionMaxLength =
-    FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_DESCRIPTION_MAX_LENGTH;
-  private int onDemandFeaturegroupFeatureNameMaxLength =
-    FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_FEATURE_NAME_MAX_LENGTH;
-  private int onDemandFeaturegroupFeatureDescriptionMaxLength =
-    FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_FEATURE_DESCRIPTION_MAX_LENGTH;
-  private int onDemandFeaturegroupSqlQueryMaxLength =
-    FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_SQL_QUERY_MAX_LENGTH;
   private List<String> trainingDatasetDataFormats = FeaturestoreConstants.TRAINING_DATASET_DATA_FORMATS;
-  private int externalTrainingDatasetNameMaxLength =
-    FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_NAME_MAX_LENGTH;
-  private int hopsfsTrainingDatasetNameMaxLength =
-    FeaturestoreConstants.HOPSFS_TRAINING_DATASET_NAME_MAX_LENGTH;
-  private int trainingDatasetFeatureNameMaxLength =
-    FeaturestoreConstants.TRAINING_DATASET_FEATURE_NAME_MAX_LENGTH;
-  private int trainingDatasetFeatureDescriptionMaxLength =
-    FeaturestoreConstants.TRAINING_DATASET_FEATURE_DESCRIPTION_MAX_LENGTH;
   private String onDemandFeaturegroupType = FeaturestoreConstants.ON_DEMAND_FEATUREGROUP_TYPE;
   private String cachedFeaturegroupType = FeaturestoreConstants.CACHED_FEATUREGROUP_TYPE;
   private String jdbcConnectorType = FeaturestoreConstants.JDBC_CONNECTOR_TYPE;
@@ -82,8 +61,6 @@ public class FeaturestoreClientSettingsDTO {
   private String externalTrainingDatasetType = FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_TYPE;
   private String hopsfsTrainingDatasetDtoType = FeaturestoreConstants.HOPSFS_TRAINING_DATASET_DTO_TYPE;
   private String externalTrainingDatasetDtoType = FeaturestoreConstants.EXTERNAL_TRAINING_DATASET_DTO_TYPE;
-  private int trainingDatasetDescriptionMaxLength =
-    FeaturestoreConstants.TRAINING_DATASET_DESCRIPTION_MAX_LENGTH;
   private String s3ConnectorDtoType = FeaturestoreConstants.S3_CONNECTOR_DTO_TYPE;
   private String jdbcConnectorDtoType = FeaturestoreConstants.JDBC_CONNECTOR_DTO_TYPE;
   private String hopsfsConnectorDtoType = FeaturestoreConstants.HOPSFS_CONNECTOR_DTO_TYPE;
@@ -121,6 +98,33 @@ public class FeaturestoreClientSettingsDTO {
   
   public void setFeaturestoreRegex(String featurestoreRegex) {
     this.featurestoreRegex = featurestoreRegex;
+  }
+  
+  @XmlElement
+  public int getFeaturestoreEntityNameMaxLength() {
+    return featurestoreEntityNameMaxLength;
+  }
+  
+  public void setFeaturestoreEntityNameMaxLength(int featurestoreEntityNameMaxLength) {
+    this.featurestoreEntityNameMaxLength = featurestoreEntityNameMaxLength;
+  }
+  
+  @XmlElement
+  public int getFeaturestoreEntityDescriptionMaxLength() {
+    return featurestoreEntityDescriptionMaxLength;
+  }
+  
+  public void setFeaturestoreEntityDescriptionMaxLength(int featurestoreEntityDescriptionMaxLength) {
+    this.featurestoreEntityDescriptionMaxLength = featurestoreEntityDescriptionMaxLength;
+  }
+  
+  @XmlElement
+  public int getOnDemandFeaturegroupSqlQueryMaxLength() {
+    return onDemandFeaturegroupSqlQueryMaxLength;
+  }
+  
+  public void setOnDemandFeaturegroupSqlQueryMaxLength(int onDemandFeaturegroupSqlQueryMaxLength) {
+    this.onDemandFeaturegroupSqlQueryMaxLength = onDemandFeaturegroupSqlQueryMaxLength;
   }
   
   @XmlElement
@@ -196,129 +200,12 @@ public class FeaturestoreClientSettingsDTO {
   }
   
   @XmlElement
-  public int getCachedFeaturegroupNameMaxLength() {
-    return cachedFeaturegroupNameMaxLength;
-  }
-  
-  public void setCachedFeaturegroupNameMaxLength(int cachedFeaturegroupNameMaxLength) {
-    this.cachedFeaturegroupNameMaxLength = cachedFeaturegroupNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getCachedFeaturegroupDescriptionMaxLength() {
-    return cachedFeaturegroupDescriptionMaxLength;
-  }
-  
-  public void setCachedFeaturegroupDescriptionMaxLength(int cachedFeaturegroupDescriptionMaxLength) {
-    this.cachedFeaturegroupDescriptionMaxLength = cachedFeaturegroupDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getCachedFeaturegroupFeatureNameMaxLength() {
-    return cachedFeaturegroupFeatureNameMaxLength;
-  }
-  
-  public void setCachedFeaturegroupFeatureNameMaxLength(int cachedFeaturegroupFeatureNameMaxLength) {
-    this.cachedFeaturegroupFeatureNameMaxLength = cachedFeaturegroupFeatureNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getCachedFeaturegroupFeatureDescriptionMaxLength() {
-    return cachedFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  public void setCachedFeaturegroupFeatureDescriptionMaxLength(int cachedFeaturegroupFeatureDescriptionMaxLength) {
-    this.cachedFeaturegroupFeatureDescriptionMaxLength = cachedFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupNameMaxLength() {
-    return onDemandFeaturegroupNameMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupNameMaxLength(int onDemandFeaturegroupNameMaxLength) {
-    this.onDemandFeaturegroupNameMaxLength = onDemandFeaturegroupNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupDescriptionMaxLength() {
-    return onDemandFeaturegroupDescriptionMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupDescriptionMaxLength(int onDemandFeaturegroupDescriptionMaxLength) {
-    this.onDemandFeaturegroupDescriptionMaxLength = onDemandFeaturegroupDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupFeatureNameMaxLength() {
-    return onDemandFeaturegroupFeatureNameMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupFeatureNameMaxLength(int onDemandFeaturegroupFeatureNameMaxLength) {
-    this.onDemandFeaturegroupFeatureNameMaxLength = onDemandFeaturegroupFeatureNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupFeatureDescriptionMaxLength() {
-    return onDemandFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupFeatureDescriptionMaxLength(int onDemandFeaturegroupFeatureDescriptionMaxLength) {
-    this.onDemandFeaturegroupFeatureDescriptionMaxLength = onDemandFeaturegroupFeatureDescriptionMaxLength;
-  }
-  
-  @XmlElement
-  public int getOnDemandFeaturegroupSqlQueryMaxLength() {
-    return onDemandFeaturegroupSqlQueryMaxLength;
-  }
-  
-  public void setOnDemandFeaturegroupSqlQueryMaxLength(int onDemandFeaturegroupSqlQueryMaxLength) {
-    this.onDemandFeaturegroupSqlQueryMaxLength = onDemandFeaturegroupSqlQueryMaxLength;
-  }
-  
-  @XmlElement
   public List<String> getTrainingDatasetDataFormats() {
     return trainingDatasetDataFormats;
   }
   
   public void setTrainingDatasetDataFormats(List<String> trainingDatasetDataFormats) {
     this.trainingDatasetDataFormats = trainingDatasetDataFormats;
-  }
-  
-  @XmlElement
-  public int getExternalTrainingDatasetNameMaxLength() {
-    return externalTrainingDatasetNameMaxLength;
-  }
-  
-  public void setExternalTrainingDatasetNameMaxLength(int externalTrainingDatasetNameMaxLength) {
-    this.externalTrainingDatasetNameMaxLength = externalTrainingDatasetNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getHopsfsTrainingDatasetNameMaxLength() {
-    return hopsfsTrainingDatasetNameMaxLength;
-  }
-  
-  public void setHopsfsTrainingDatasetNameMaxLength(int hopsfsTrainingDatasetNameMaxLength) {
-    this.hopsfsTrainingDatasetNameMaxLength = hopsfsTrainingDatasetNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getTrainingDatasetFeatureNameMaxLength() {
-    return trainingDatasetFeatureNameMaxLength;
-  }
-  
-  public void setTrainingDatasetFeatureNameMaxLength(int trainingDatasetFeatureNameMaxLength) {
-    this.trainingDatasetFeatureNameMaxLength = trainingDatasetFeatureNameMaxLength;
-  }
-  
-  @XmlElement
-  public int getTrainingDatasetFeatureDescriptionMaxLength() {
-    return trainingDatasetFeatureDescriptionMaxLength;
-  }
-  
-  public void setTrainingDatasetFeatureDescriptionMaxLength(int trainingDatasetFeatureDescriptionMaxLength) {
-    this.trainingDatasetFeatureDescriptionMaxLength = trainingDatasetFeatureDescriptionMaxLength;
   }
   
   @XmlElement
@@ -418,15 +305,6 @@ public class FeaturestoreClientSettingsDTO {
   
   public void setExternalTrainingDatasetDtoType(String externalTrainingDatasetDtoType) {
     this.externalTrainingDatasetDtoType = externalTrainingDatasetDtoType;
-  }
-  
-  @XmlElement
-  public int getTrainingDatasetDescriptionMaxLength() {
-    return trainingDatasetDescriptionMaxLength;
-  }
-  
-  public void setTrainingDatasetDescriptionMaxLength(int trainingDatasetDescriptionMaxLength) {
-    this.trainingDatasetDescriptionMaxLength = trainingDatasetDescriptionMaxLength;
   }
   
   @XmlElement

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetController.java
@@ -140,7 +140,7 @@ public class TrainingDatasetController {
   public TrainingDatasetDTO createTrainingDataset(Users user, Featurestore featurestore,
     TrainingDatasetDTO trainingDatasetDTO) throws FeaturestoreException {
     // Verify general entity related information
-    featurestoreInputValidation.verifyUserInput(trainingDatasetDTO, false);
+    featurestoreInputValidation.verifyUserInput(trainingDatasetDTO);
     // Verify input specific for training dataset
     verifyTrainingDatasetInput(trainingDatasetDTO, featurestore);
     // Statistics
@@ -336,7 +336,7 @@ public class TrainingDatasetController {
     TrainingDataset trainingDataset = verifyTrainingDatasetId(trainingDatasetDTO.getId(), featurestore);
   
     // Verify general entity related information
-    featurestoreInputValidation.verifyUserInput(trainingDatasetDTO, false);
+    featurestoreInputValidation.verifyUserInput(trainingDatasetDTO);
   
     // Verify training dataset specific information
     verifyTrainingDatasetDataFormat(trainingDatasetDTO.getDataFormat());

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
@@ -1,0 +1,83 @@
+package io.hops.hopsworks.common.featurestore.utils;
+
+import com.google.common.base.Strings;
+import io.hops.hopsworks.common.featurestore.FeaturestoreConstants;
+import io.hops.hopsworks.common.featurestore.FeaturestoreEntityDTO;
+import io.hops.hopsworks.common.featurestore.feature.FeatureDTO;
+import io.hops.hopsworks.exceptions.FeaturestoreException;
+import io.hops.hopsworks.restutils.RESTCodes;
+
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+@Stateless
+@TransactionAttribute(TransactionAttributeType.NEVER)
+public class FeaturestoreInputValidation {
+  
+  public FeaturestoreInputValidation() {
+  }
+  
+  /**
+   * Verify entity names input by the user for creation of entities in the featurestore
+   *
+   * @param featurestoreEntityDTO the user input data for the entity
+   * @throws FeaturestoreException
+   */
+  public void verifyUserInput(FeaturestoreEntityDTO featurestoreEntityDTO, Boolean sync)
+    throws FeaturestoreException {
+    
+    Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
+    
+    // name
+    if (!namePattern.matcher(featurestoreEntityDTO.getName()).matches()) {
+      throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_ENTITY_NAME, Level.FINE,
+        ", the provided name " + featurestoreEntityDTO.getName() + " is invalid. Entity names can only contain lower " +
+          "case characters, numbers and underscores and cannot be longer than " +
+          FeaturestoreConstants.FEATURESTORE_ENTITY_NAME_MAX_LENGTH + " characters or empty.");
+    }
+    
+    // description - can be empty
+    if (!Strings.isNullOrEmpty(featurestoreEntityDTO.getDescription()) &&
+      featurestoreEntityDTO.getDescription().length() >
+        FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH) {
+      throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_ENTITY_DESCRIPTION, Level.FINE,
+        ", the provided description for the entity " + featurestoreEntityDTO.getName() + " is too long. Entity " +
+          "descriptions cannot be longer than " + FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH +
+          " characters.");
+    }
+    
+    // features
+    // Only need to verify the DDL when creating table from Scratch and not Syncing
+    if (!sync) {
+      verifyFeatureList(featurestoreEntityDTO.getFeatures());
+    }
+  }
+  
+  /**
+   * Verifies the user input feature list for a feature store entity
+   *
+   * @param featureDTOs the feature list to verify
+   */
+  private void verifyFeatureList(List<FeatureDTO> featureDTOs) throws FeaturestoreException {
+    if(featureDTOs != null && !featureDTOs.isEmpty()) {
+      Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
+      if (featureDTOs.stream().anyMatch(f -> !namePattern.matcher(f.getName()).matches())) {
+        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_NAME, Level.FINE,
+          ", one or more of the provided feature names is invalid. Feature names can only contain lower " +
+            "case characters, numbers and underscores and cannot be longer than " +
+            FeaturestoreConstants.FEATURESTORE_ENTITY_NAME_MAX_LENGTH + " characters or empty.");
+      }
+  
+      if (featureDTOs.stream().anyMatch(f -> !Strings.isNullOrEmpty(f.getDescription()) &&
+        f.getDescription().length() > FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH)) {
+        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_DESCRIPTION, Level.FINE,
+          ", one or more of the provided feature descriptions is too long. Feature descriptions cannot be longer than "
+            + FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH + " characters.");
+      }
+    }
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2019, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package io.hops.hopsworks.common.featurestore.utils;
 
 import com.google.common.base.Strings;

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
@@ -43,7 +43,7 @@ public class FeaturestoreInputValidation {
    * @param featurestoreEntityDTO the user input data for the entity
    * @throws FeaturestoreException
    */
-  public void verifyUserInput(FeaturestoreEntityDTO featurestoreEntityDTO, Boolean sync)
+  public void verifyUserInput(FeaturestoreEntityDTO featurestoreEntityDTO)
     throws FeaturestoreException {
     
     Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
@@ -67,10 +67,7 @@ public class FeaturestoreInputValidation {
     }
     
     // features
-    // Only need to verify the DDL when creating table from Scratch and not Syncing
-    if (!sync) {
-      verifyFeatureList(featurestoreEntityDTO.getFeatures());
-    }
+    verifyFeatureList(featurestoreEntityDTO.getFeatures());
   }
   
   /**

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/utils/FeaturestoreInputValidation.java
@@ -45,9 +45,9 @@ public class FeaturestoreInputValidation {
       featurestoreEntityDTO.getDescription().length() >
         FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_ENTITY_DESCRIPTION, Level.FINE,
-        ", the provided description for the entity " + featurestoreEntityDTO.getName() + " is too long. Entity " +
-          "descriptions cannot be longer than " + FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH +
-          " characters.");
+        ", the provided description for the entity " + featurestoreEntityDTO.getName() + " is too long with "
+          + featurestoreEntityDTO.getDescription().length() + " characters. Entity descriptions cannot be longer than "
+          + FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH + " characters.");
     }
     
     // features
@@ -63,20 +63,22 @@ public class FeaturestoreInputValidation {
    * @param featureDTOs the feature list to verify
    */
   private void verifyFeatureList(List<FeatureDTO> featureDTOs) throws FeaturestoreException {
-    if(featureDTOs != null && !featureDTOs.isEmpty()) {
+    if (featureDTOs != null && !featureDTOs.isEmpty()) {
       Pattern namePattern = FeaturestoreConstants.FEATURESTORE_REGEX;
-      if (featureDTOs.stream().anyMatch(f -> !namePattern.matcher(f.getName()).matches())) {
-        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_NAME, Level.FINE,
-          ", one or more of the provided feature names is invalid. Feature names can only contain lower " +
-            "case characters, numbers and underscores and cannot be longer than " +
-            FeaturestoreConstants.FEATURESTORE_ENTITY_NAME_MAX_LENGTH + " characters or empty.");
-      }
-  
-      if (featureDTOs.stream().anyMatch(f -> !Strings.isNullOrEmpty(f.getDescription()) &&
-        f.getDescription().length() > FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH)) {
-        throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_DESCRIPTION, Level.FINE,
-          ", one or more of the provided feature descriptions is too long. Feature descriptions cannot be longer than "
-            + FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH + " characters.");
+      for (FeatureDTO featureDTO : featureDTOs) {
+        if (!namePattern.matcher(featureDTO.getName()).matches()) {
+          throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_NAME, Level.FINE,
+            ", the provided feature name " + featureDTO.getName() + " is invalid. Feature names can only contain " +
+              "lower case characters, numbers and underscores and cannot be longer than " +
+              FeaturestoreConstants.FEATURESTORE_ENTITY_NAME_MAX_LENGTH + " characters or empty.");
+        }
+        if (!Strings.isNullOrEmpty(featureDTO.getDescription()) &&
+          featureDTO.getDescription().length() > FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH) {
+          throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ILLEGAL_FEATURE_DESCRIPTION, Level.FINE,
+            ", the provided feature description of " + featureDTO.getName() + " is too long with " +
+              featureDTO.getDescription().length() + " characters. Feature descriptions cannot be longer than " +
+              FeaturestoreConstants.FEATURESTORE_ENTITY_DESCRIPTION_MAX_LENGTH + " characters.");
+        }
       }
     }
   }

--- a/hopsworks-rest-utils/src/main/java/io/hops/hopsworks/restutils/RESTCodes.java
+++ b/hopsworks-rest-utils/src/main/java/io/hops/hopsworks/restutils/RESTCodes.java
@@ -1335,9 +1335,6 @@ public class RESTCodes {
       Response.Status.BAD_REQUEST),
     ILLEGAL_HOPSFS_CONNECTOR_DATASET(37, "Illegal Hopsfs connector dataset",
       Response.Status.BAD_REQUEST),
-    ILLEGAL_FEATUREGROUP_NAME(38, "Illegal feature group name", Response.Status.BAD_REQUEST),
-    ILLEGAL_FEATUREGROUP_DESCRIPTION(39, "Illegal feature group description",
-      Response.Status.BAD_REQUEST),
     ILLEGAL_FEATURE_NAME(40, "Illegal feature name",
       Response.Status.BAD_REQUEST),
     ILLEGAL_FEATURE_DESCRIPTION(41, "Illegal feature description",
@@ -1359,11 +1356,8 @@ public class RESTCodes {
       " supported", Response.Status.BAD_REQUEST),
     TRAINING_DATASET_VERSION_NOT_PROVIDED(52, "Training Dataset version was not provided",
       Response.Status.BAD_REQUEST),
-    ILLEGAL_TRAINING_DATASET_NAME(53, "Illegal training dataset name", Response.Status.BAD_REQUEST),
     S3_CONNECTOR_ID_NOT_PROVIDED(54, "S3 Connector Id was not provided", Response.Status.BAD_REQUEST),
     HOPSFS_CONNECTOR_ID_NOT_PROVIDED(55, "HopsFS Connector Id was not provided", Response.Status.BAD_REQUEST),
-    ILLEGAL_TRAINING_DATASET_DESCRIPTION(56, "Illegal training dataset description",
-      Response.Status.BAD_REQUEST),
     ILLEGAL_TRAINING_DATASET_DATA_FORMAT(57, "Illegal training dataset data format",
       Response.Status.BAD_REQUEST),
     ILLEGAL_TRAINING_DATASET_VERSION(58, "Illegal training dataset version",
@@ -1428,7 +1422,11 @@ public class RESTCodes {
       Response.Status.BAD_REQUEST),
     XATTRS_OPERATIONS_ONLY_SUPPORTED_FOR_CACHED_FEATUREGROUPS(90, "Attaching " +
         "extended attributes is only supported for cached featuregroups.",
-        Response.Status.BAD_REQUEST);
+        Response.Status.BAD_REQUEST),
+    ILLEGAL_ENTITY_NAME(91, "Illegal feature store entity name", Response.Status.BAD_REQUEST),
+    ILLEGAL_ENTITY_DESCRIPTION(92, "Illegal featurestore entity description", Response.Status.BAD_REQUEST),
+    ERROR_UPDATING_METADATA(93, "An error occurred when trying to update feature store metadata",
+      Response.Status.BAD_REQUEST);
 
     private int code;
     private String message;

--- a/hopsworks-web/yo/app/scripts/controllers/newFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/newFeaturegroupCtrl.js
@@ -108,14 +108,8 @@ angular.module('hopsWorksApp')
             //Constants
             self.hiveDatabases = [self.featurestore.featurestoreName, self.projectName]
             self.hiveRegexp = self.settings.featurestoreRegex;
-            self.cachedFeaturegroupNameMaxLength = self.settings.cachedFeaturegroupFeatureNameMaxLength
-            self.cachedFeaturegroupDescriptionMaxLength = self.settings.cachedFeaturegroupFeatureDescriptionMaxLength
-            self.cachedFeaturegroupFeatureNameMaxLength = self.settings.cachedFeaturegroupFeatureNameMaxLength
-            self.cachedFeaturegroupFeatureDescriptionMaxLength = self.settings.cachedFeaturegroupFeatureDescriptionMaxLength
-            self.onDemandFeaturegroupNameMaxLength = self.settings.onDemandFeaturegroupNameMaxLength
-            self.onDemandFeaturegroupDescriptionMaxLength = self.settings.onDemandFeaturegroupDescriptionMaxLength
-            self.onDemandFeaturegroupFeatureNameMaxLength = self.settings.onDemandFeaturegroupFeatureNameMaxLength
-            self.onDemandFeaturegroupFeatureDescriptionMaxLength = self.settings.onDemandFeaturegroupFeatureDescriptionMaxLength
+            self.featurestoreEntityNameMaxLength = self.settings.featurestoreEntityNameMaxLength
+            self.featurestoreEntityDescriptionMaxLength = self.settings.featurestoreEntityDescriptionMaxLength
             self.onDemandFeaturegroupType = self.settings.onDemandFeaturegroupType
             self.cachedFeaturegroupType = self.settings.cachedFeaturegroupType
             self.onDemandFeaturegroupSqlQueryMaxLength = self.settings.onDemandFeaturegroupSqlQueryMaxLength
@@ -558,8 +552,7 @@ angular.module('hopsWorksApp')
                 }
 
                 //Validate Name and Description
-                if (!self.onDemandFeaturegroupName || self.onDemandFeaturegroupName.search(self.hiveRegexp) == -1
-                    || self.onDemandFeaturegroupName.length > self.onDemandFeaturegroupNameMaxLength) {
+                if (!self.onDemandFeaturegroupName || self.onDemandFeaturegroupName.search(self.hiveRegexp) == -1) {
                     self.onDemandFeaturegroupNameWrongValue = -1;
                     self.onDemandFeaturegroupWrong_values = -1;
                 } else {
@@ -568,7 +561,7 @@ angular.module('hopsWorksApp')
                 if (!self.onDemandFeaturegroupDoc || self.onDemandFeaturegroupDoc == undefined) {
                     self.onDemandFeaturegroupDoc = ""
                 }
-                if (self.onDemandFeaturegroupDoc && self.onDemandFeaturegroupDoc.length > self.onDemandFeaturegroupDescriptionMaxLength) {
+                if (self.onDemandFeaturegroupDoc && self.onDemandFeaturegroupDoc.length > self.featurestoreEntityDescriptionMaxLength) {
                     self.onDemandFeaturegroupDocWrongValue = -1;
                     self.onDemandFeaturegroupWrong_values = -1;
                 } else {
@@ -581,8 +574,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.onDemandFeaturegroupFeatures.length; i++) {
                     featureNames.push(self.onDemandFeaturegroupFeatures[i].name)
-                    if (self.onDemandFeaturegroupFeatures[i].name === "" || self.onDemandFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1 ||
-                        self.onDemandFeaturegroupFeatures[i].name.length > self.onDemandFeaturegroupFeatureNameMaxLength) {
+                    if (self.onDemandFeaturegroupFeatures[i].name === "" || self.onDemandFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1) {
                         self.onDemandFeaturegroupFeaturesNameWrongValue[i] = -1
                         self.onDemandFeaturegroupWrong_values = -1;
                         self.onDemandFeaturegroupFeaturesWrongValue = -1;
@@ -593,7 +585,7 @@ angular.module('hopsWorksApp')
                         self.onDemandFeaturegroupFeaturesWrongValue = -1;
                     }
                     if (self.onDemandFeaturegroupFeatures[i].description && self.onDemandFeaturegroupFeatures[i].description.length >
-                        self.onDemandFeaturegroupFeatureDescriptionMaxLength) {
+                        self.featurestoreEntityDescriptionMaxLength) {
                         self.onDemandFeaturegroupFeaturesDocWrongValue[i] = -1
                         self.onDemandFeaturegroupWrong_values = -1;
                         self.onDemandFeaturegroupFeaturesWrongValue = -1;
@@ -680,8 +672,7 @@ angular.module('hopsWorksApp')
                 }
 
                 //Validate Name and Description
-                if (!self.cachedFeaturegroupName || self.cachedFeaturegroupName.search(self.hiveRegexp) == -1
-                    || self.cachedFeaturegroupName.length > self.cachedFeaturegroupNameMaxLength) {
+                if (!self.cachedFeaturegroupName || self.cachedFeaturegroupName.search(self.hiveRegexp) == -1) {
                     self.cachedFeaturegroupNameWrongValue = -1;
                     self.cachedFeaturegroupWrong_values = -1;
                 } else {
@@ -690,7 +681,7 @@ angular.module('hopsWorksApp')
                 if (!self.cachedFeaturegroupDoc || self.cachedFeaturegroupDoc == undefined) {
                     self.cachedFeaturegroupDoc = ""
                 }
-                if (self.cachedFeaturegroupDoc && self.cachedFeaturegroupDoc.length > self.cachedFeaturegroupDescriptionMaxLength) {
+                if (self.cachedFeaturegroupDoc && self.cachedFeaturegroupDoc.length > self.featurestoreEntityDescriptionMaxLength) {
                     self.cachedFeaturegroupDocWrongValue = -1;
                     self.cachedFeaturegroupWrong_values = -1;
                 } else {
@@ -703,8 +694,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.cachedFeaturegroupFeatures.length; i++) {
                     featureNames.push(self.cachedFeaturegroupFeatures[i].name)
-                    if (self.cachedFeaturegroupFeatures[i].name === "" || self.cachedFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1 ||
-                        self.cachedFeaturegroupFeatures[i].name.length > self.cachedFeaturegroupFeatureNameMaxLength) {
+                    if (self.cachedFeaturegroupFeatures[i].name === "" || self.cachedFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1 ) {
                         self.cachedFeaturegroupFeaturesNameWrongValue[i] = -1
                         self.cachedFeaturegroupWrong_values = -1;
                         self.cachedFeaturegroupFeaturesWrongValue = -1;
@@ -722,7 +712,7 @@ angular.module('hopsWorksApp')
                         self.cachedFeaturegroupFeaturesWrongValue = -1;
                     }
                     if (self.cachedFeaturegroupFeatures[i].description && self.cachedFeaturegroupFeatures[i].description.length >
-                        self.cachedFeaturegroupFeatureDescriptionMaxLength) {
+                        self.featurestoreEntityDescriptionMaxLength) {
                         self.cachedFeaturegroupFeaturesDocWrongValue[i] = -1
                         self.cachedFeaturegroupWrong_values = -1;
                         self.cachedFeaturegroupFeaturesWrongValue = -1;

--- a/hopsworks-web/yo/app/scripts/controllers/newFeaturegroupCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/newFeaturegroupCtrl.js
@@ -574,7 +574,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.onDemandFeaturegroupFeatures.length; i++) {
                     featureNames.push(self.onDemandFeaturegroupFeatures[i].name)
-                    if (self.onDemandFeaturegroupFeatures[i].name === "" || self.onDemandFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1) {
+                    if (self.onDemandFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1) {
                         self.onDemandFeaturegroupFeaturesNameWrongValue[i] = -1
                         self.onDemandFeaturegroupWrong_values = -1;
                         self.onDemandFeaturegroupFeaturesWrongValue = -1;
@@ -694,7 +694,7 @@ angular.module('hopsWorksApp')
                 var numberOfPrimary = 0
                 for (i = 0; i < self.cachedFeaturegroupFeatures.length; i++) {
                     featureNames.push(self.cachedFeaturegroupFeatures[i].name)
-                    if (self.cachedFeaturegroupFeatures[i].name === "" || self.cachedFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1 ) {
+                    if (self.cachedFeaturegroupFeatures[i].name.search(self.hiveRegexp) == -1 ) {
                         self.cachedFeaturegroupFeaturesNameWrongValue[i] = -1
                         self.cachedFeaturegroupWrong_values = -1;
                         self.cachedFeaturegroupFeaturesWrongValue = -1;

--- a/hopsworks-web/yo/app/scripts/controllers/newTrainingDatasetCtrl.js
+++ b/hopsworks-web/yo/app/scripts/controllers/newTrainingDatasetCtrl.js
@@ -68,8 +68,8 @@ angular.module('hopsWorksApp')
             self.path = ""
 
             //Constants
-            self.trainingDatasetNameMaxLength = self.settings.hopsfsTrainingDatasetNameMaxLength
-            self.trainingDatasetDescriptionMaxLength = self.settings.trainingDatasetDescriptionMaxLength
+            self.trainingDatasetNameMaxLength = self.settings.featurestoreEntityNameMaxLength
+            self.trainingDatasetDescriptionMaxLength = self.settings.featurestoreEntityDescriptionMaxLength
             self.trainingDatasetNameRegexp = self.settings.featurestoreRegex
             self.dataFormats = self.settings.trainingDatasetDataFormats
             self.hopsfsTrainingDatasetType = self.settings.hopsfsTrainingDatasetType
@@ -229,8 +229,7 @@ angular.module('hopsWorksApp')
                 self.trainingDatasetSinkNotSelected = 1
                 self.sinkWrongValue = 1
                 self.working = true;
-                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1
-                    || self.trainingDatasetName.length > self.trainingDatasetNameMaxLength) {
+                if (!self.trainingDatasetName || self.trainingDatasetName.search(self.trainingDatasetNameRegexp) == -1) {
                     self.trainingDatasetNameWrongValue = -1;
                     self.trainingDatasetWrong_values = -1;
                 } else {

--- a/hopsworks-web/yo/app/views/newFeaturegroup.html
+++ b/hopsworks-web/yo/app/views/newFeaturegroup.html
@@ -87,7 +87,7 @@
                                     <p>
                                         Feature Group Name shouldn't be empty and can only contain lower
                                         case, alphanumeric characters and underscores,
-                                        maximum length is {{newFeaturegroupCtrl.cachedFeaturegroupNameMaxLength}}
+                                        maximum length is {{newFeaturegroupCtrl.featurestoreEntityNameMaxLength}}
                                         characters. Hyphens are not allowed in the name.
                                     </p>
                                 </div>
@@ -120,7 +120,7 @@
                                         style="color: red">
                                     <p>
                                         Feature Group Description should not exceed the maximum length of
-                                        {{newFeaturegroupCtrl.cachedFeaturegroupNameMaxLength}} characters.
+                                        {{newFeaturegroupCtrl.featurestoreEntityDescriptionMaxLength}} characters.
                                     </p>
                                 </div>
                             </div>
@@ -166,7 +166,7 @@
                                                             alphanumeric characters and
                                                             underscores and max length
                                                             is
-                                                            {{newFeaturegroupCtrl.cachedFeaturegroupFeatureNameMaxLength}}
+                                                            {{newFeaturegroupCtrl.featurestoreEntityNameMaxLength}}
                                                             characters. Hyphens are not allowed in the feature name.</p>
                                                     </div>
                                                 </div>
@@ -248,7 +248,7 @@
                                                             style="color: red">
                                                         <p>
                                                             Feature description should not exceed
-                                                            {{newFeaturegroupCtrl.cachedFeaturegroupFeatureDescriptionMaxLength}}
+                                                            {{newFeaturegroupCtrl.featurestoreEntityDescriptionMaxLength}}
                                                             characters
                                                         </p>
                                                     </div>
@@ -670,7 +670,7 @@
                                     <p>
                                         Feature Group Name shouldn't be empty and can only contain alphanumeric
                                         characters and underscores,
-                                        maximum length is {{newFeaturegroupCtrl.onDemandFeaturegroupNameMaxLength}}
+                                        maximum length is {{newFeaturegroupCtrl.featurestoreEntityNameMaxLength}}
                                         characters.
                                         Hyphens are not allowed in the name.
                                     </p>
@@ -704,7 +704,7 @@
                                         style="color: red">
                                     <p>
                                         Feature Group Description should not exceed the maximum length of
-                                        {{newFeaturegroupCtrl.onDemandFeaturegroupNameMaxLength}} characters.
+                                        {{newFeaturegroupCtrl.featurestoreEntityDescriptionMaxLength}} characters.
                                     </p>
                                 </div>
                             </div>
@@ -751,7 +751,7 @@
                                                             alphanumeric characters and
                                                             underscores and max length
                                                             is
-                                                            {{newFeaturegroupCtrl.onDemandFeaturegroupFeatureNameMaxLength}}
+                                                            {{newFeaturegroupCtrl.featurestoreEntityNameMaxLength}}
                                                             characters. Hyphens are not allowed in the feature name.</p>
                                                     </div>
                                                 </div>
@@ -805,7 +805,7 @@
                                                             style="color: red">
                                                         <p>
                                                             Feature description should not exceed
-                                                            {{newFeaturegroupCtrl.onDemandFeaturegroupFeatureDescriptionMaxLength}}
+                                                            {{newFeaturegroupCtrl.featurestoreEntityDescriptionMaxLength}}
                                                             characters
                                                         </p>
                                                     </div>

--- a/hopsworks-web/yo/app/views/newTrainingDataset.html
+++ b/hopsworks-web/yo/app/views/newTrainingDataset.html
@@ -413,7 +413,7 @@
                                 <p>
                                     Training dataset name shouldn't be empty and can only contain lower case
                                     alphanumeric characters and underscores, maximum length is
-                                    {{newTrainingDatasetCtrl.trainingDatasetDescriptionMaxLength}}
+                                    {{newTrainingDatasetCtrl.trainingDatasetNameMaxLength}}
                                     characters. Hyphens are not allowed in the training dataset name.
                                 </p>
                             </div>
@@ -446,7 +446,7 @@
                                     style="color: red">
                                 <p>
                                     Training Dataset Description should not exceed the maximum length of
-                                    {{newTrainingDatasetCtrl.trainingDatasetNameMaxLength}} characters.
+                                    {{newTrainingDatasetCtrl.trainingDatasetDescriptionMaxLength}} characters.
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit

Featurestore Tests were run locally.

* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1435

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Unifies the validation of name and description lengths in the backend in order to avoid duplicated code in each controller.

Updating the schema of a training dataset from the UI was buggy and led to a situation where features are accumulated in the schema, because we did not remove the old ones correctly and just added the new ones. This gets fixed with this PR.

* **What is the new behavior (if this is a feature change)?**
The update metadata endpoint will not let you update the metadata of a cached feature group anymore. We never used the endpoint for this since it will require to recreate the Hive table anyway, and the functionality was broken.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
