### PR TITLE
[HOPSWORKS-1678] Extend training dataset endpoint to save train-test split information as metadata

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetController.java
@@ -49,6 +49,7 @@ import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.Trainin
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.TrainingDatasetType;
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.external.ExternalTrainingDataset;
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.hopsfs.HopsfsTrainingDataset;
+import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.split.TrainingDatasetSplit;
 import io.hops.hopsworks.persistence.entity.hdfs.inode.Inode;
 import io.hops.hopsworks.persistence.entity.jobs.description.Jobs;
 import io.hops.hopsworks.persistence.entity.project.Project;
@@ -265,6 +266,10 @@ public class TrainingDatasetController {
     trainingDataset.setCreator(user);
     trainingDataset.setVersion(trainingDatasetDTO.getVersion());
     trainingDataset.setTrainingDatasetType(trainingDatasetDTO.getTrainingDatasetType());
+    trainingDataset.setSeed(trainingDatasetDTO.getSeed());
+    trainingDataset.setSplits(trainingDatasetDTO.getSplits().stream()
+      .map(tdDTO -> new TrainingDatasetSplit(trainingDataset, tdDTO.getName(), tdDTO.getPercentage())).collect(
+        Collectors.toList()));
     trainingDatasetFacade.persist(trainingDataset);
   
     // Store statistics

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetDTO.java
@@ -132,6 +132,7 @@ public class TrainingDatasetDTO extends FeaturestoreEntityDTO {
     this.splits = splits;
   }
   
+  @XmlElement
   public Long getSeed() {
     return seed;
   }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetDTO.java
@@ -16,6 +16,7 @@
 
 package io.hops.hopsworks.common.featurestore.trainingdatasets;
 
+import io.hops.hopsworks.common.featurestore.trainingdatasets.split.TrainingDatasetSplitDTO;
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.TrainingDataset;
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.TrainingDatasetType;
 import io.hops.hopsworks.common.featurestore.FeaturestoreEntityDTO;
@@ -36,6 +37,8 @@ public class TrainingDatasetDTO extends FeaturestoreEntityDTO {
   
   private String dataFormat;
   private TrainingDatasetType trainingDatasetType;
+  private List<TrainingDatasetSplitDTO> splits;
+  private Long seed;
 
   private Integer storageConnectorId; // Need to know which storage connector to use it
   // ID + type would be unique. However momentarily keep also the name, until we switch to
@@ -52,16 +55,20 @@ public class TrainingDatasetDTO extends FeaturestoreEntityDTO {
 
   public TrainingDatasetDTO(TrainingDataset trainingDataset) {
     super(trainingDataset.getFeaturestore().getId(),
-        trainingDataset.getName(),
-        trainingDataset.getCreated(),
-        trainingDataset.getCreator(), trainingDataset.getVersion(),
-        (List) trainingDataset.getStatistics(), (List) trainingDataset.getJobs(),
-        trainingDataset.getId());
+      trainingDataset.getName(),
+      trainingDataset.getCreated(),
+      trainingDataset.getCreator(), trainingDataset.getVersion(),
+      (List) trainingDataset.getStatistics(), (List) trainingDataset.getJobs(),
+      trainingDataset.getId());
     setDescription(trainingDataset.getDescription());
     setFeatures(trainingDataset.getFeatures().stream().map(tdf -> new FeatureDTO(tdf.getName(),
-        tdf.getType(), tdf.getDescription(), tdf.getPrimary(), false, null)).collect(Collectors.toList()));
+      tdf.getType(), tdf.getDescription(), tdf.getPrimary(), false, null)).collect(Collectors.toList()));
     this.dataFormat = trainingDataset.getDataFormat();
     this.trainingDatasetType = trainingDataset.getTrainingDatasetType();
+    this.splits =
+      trainingDataset.getSplits().stream().map(tds -> new TrainingDatasetSplitDTO(tds.getName(), tds.getPercentage()))
+        .collect(Collectors.toList());
+    this.seed = trainingDataset.getSeed();
   }
   
   @XmlElement
@@ -115,11 +122,35 @@ public class TrainingDatasetDTO extends FeaturestoreEntityDTO {
     this.trainingDatasetType = trainingDatasetType;
   }
 
+  @XmlElement
+  public List<TrainingDatasetSplitDTO> getSplits() {
+    return splits;
+  }
+  
+  public void setSplits(
+    List<TrainingDatasetSplitDTO> splits) {
+    this.splits = splits;
+  }
+  
+  public Long getSeed() {
+    return seed;
+  }
+  
+  public void setSeed(Long seed) {
+    this.seed = seed;
+  }
+  
   @Override
   public String toString() {
     return "TrainingDatasetDTO{" +
       "dataFormat='" + dataFormat + '\'' +
       ", trainingDatasetType=" + trainingDatasetType +
+      ", splits=" + splits +
+      ", seed=" + seed +
+      ", storageConnectorId=" + storageConnectorId +
+      ", storageConnectorName='" + storageConnectorName + '\'' +
+      ", storageConnectorType=" + storageConnectorType +
+      ", inodeId=" + inodeId +
       '}';
   }
 }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/split/TrainingDatasetSplitDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/split/TrainingDatasetSplitDTO.java
@@ -1,0 +1,49 @@
+package io.hops.hopsworks.common.featurestore.trainingdatasets.split;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * DTO containing the human-readable information of a training dataset split, can be converted to JSON or XML
+ * representation using jaxb.
+ */
+@XmlRootElement
+@XmlType(propOrder = {"name", "percentage"})
+public class TrainingDatasetSplitDTO {
+  @XmlElement
+  private String name;
+  @XmlElement
+  private float percentage;
+  
+  public TrainingDatasetSplitDTO(){}
+  
+  public TrainingDatasetSplitDTO(String name, float percentage) {
+    this.name = name;
+    this.percentage = percentage;
+  }
+  
+  public String getName() {
+    return name;
+  }
+  
+  public void setName(String name) {
+    this.name = name;
+  }
+  
+  public float getPercentage() {
+    return percentage;
+  }
+  
+  public void setPercentage(float percentage) {
+    this.percentage = percentage;
+  }
+  
+  @Override
+  public String toString() {
+    return "TrainingDatasetSplitDTO{" +
+      "name='" + name + '\'' +
+      ", percentage=" + percentage +
+      '}';
+  }
+}

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/split/TrainingDatasetSplitDTO.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/split/TrainingDatasetSplitDTO.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2020, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package io.hops.hopsworks.common.featurestore.trainingdatasets.split;
 
 import javax.xml.bind.annotation.XmlElement;

--- a/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/featurestore/trainingdataset/TrainingDataset.java
+++ b/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/featurestore/trainingdataset/TrainingDataset.java
@@ -23,6 +23,7 @@ import io.hops.hopsworks.persistence.entity.featurestore.statistics.Featurestore
 
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.external.ExternalTrainingDataset;
 import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.hopsfs.HopsfsTrainingDataset;
+import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.split.TrainingDatasetSplit;
 import io.hops.hopsworks.persistence.entity.user.Users;
 
 import javax.persistence.Basic;
@@ -100,6 +101,9 @@ public class TrainingDataset implements Serializable {
   @Basic(optional = false)
   @Column(name = "description")
   private String description;
+  @Basic
+  @Column(name = "seed")
+  private Long seed;
   @OneToMany(cascade = CascadeType.ALL, mappedBy = "trainingDataset")
   private Collection<FeaturestoreStatistic> statistics;
   @OneToMany(cascade = CascadeType.ALL, mappedBy = "trainingDataset")
@@ -116,6 +120,8 @@ public class TrainingDataset implements Serializable {
   @JoinColumn(name = "external_training_dataset_id", referencedColumnName = "id")
   @OneToOne
   private ExternalTrainingDataset externalTrainingDataset;
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "trainingDataset")
+  private Collection<TrainingDatasetSplit> splits;
 
   public static long getSerialVersionUID() {
     return serialVersionUID;
@@ -235,7 +241,24 @@ public class TrainingDataset implements Serializable {
   public void setName(String name) {
     this.name = name;
   }
-
+  
+  public Collection<TrainingDatasetSplit> getSplits() {
+    return splits;
+  }
+  
+  public void setSplits(
+    Collection<TrainingDatasetSplit> splits) {
+    this.splits = splits;
+  }
+  
+  public Long getSeed() {
+    return seed;
+  }
+  
+  public void setSeed(Long seed) {
+    this.seed = seed;
+  }
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -255,6 +278,8 @@ public class TrainingDataset implements Serializable {
     if (!Objects.equals(features, that.features)) return false;
     if (!Objects.equals(jobs, that.jobs)) return false;
     if (trainingDatasetType != that.trainingDatasetType) return false;
+    if (!Objects.equals(splits, that.splits)) return false;
+    if (!Objects.equals(seed, that.seed)) return false;
     if (!Objects.equals(hopsfsTrainingDataset, that.hopsfsTrainingDataset))
       return false;
     return Objects.equals(externalTrainingDataset, that.externalTrainingDataset);
@@ -276,6 +301,8 @@ public class TrainingDataset implements Serializable {
     result = 31 * result + (trainingDatasetType != null ? trainingDatasetType.hashCode() : 0);
     result = 31 * result + (hopsfsTrainingDataset != null ? hopsfsTrainingDataset.hashCode() : 0);
     result = 31 * result + (externalTrainingDataset != null ? externalTrainingDataset.hashCode() : 0);
+    result = 31 * result + (splits != null ? splits.hashCode() : 0);
+    result = 31 * result + (seed != null ? seed.hashCode() : 0);
     return result;
   }
 }

--- a/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/featurestore/trainingdataset/split/TrainingDatasetSplit.java
+++ b/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/featurestore/trainingdataset/split/TrainingDatasetSplit.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Hopsworks
+ * Copyright (C) 2020, Logical Clocks AB. All rights reserved
+ *
+ * Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU Affero General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.split;
+
+import io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.TrainingDataset;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+/**
+ * Entity class representing the training_dataset_split table in Hopsworks database.
+ * An instance of this class represents a row in the database.
+ */
+@Entity
+@Table(name = "training_dataset_split", catalog = "hopsworks")
+@XmlRootElement
+@NamedQueries({
+  @NamedQuery(name = "TrainingDatasetSplit.findAll", query = "SELECT split FROM TrainingDatasetSplit split"),
+  @NamedQuery(name = "TrainingDatasetSplit.findById",
+    query = "SELECT split FROM TrainingDatasetSplit split WHERE split.id = :id"),
+  @NamedQuery(name = "TrainingDatasetSplit.findByTrainingDataset",
+    query = "SELECT split FROM TrainingDatasetSplit split WHERE split.trainingDataset = :training_dataset")})
+public class TrainingDatasetSplit implements Serializable {
+  private static final long serialVersionUID = 1L;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Basic(optional = false)
+  @Column(name = "id")
+  private Integer id;
+  @JoinColumn(name = "training_dataset_id", referencedColumnName = "id")
+  private TrainingDataset trainingDataset;
+  @Column(name = "name")
+  @Basic(optional = false)
+  private String name;
+  @Column(name = "percentage")
+  @Basic(optional = false)
+  private float percentage;
+  
+  public TrainingDatasetSplit() {
+  }
+  
+  public TrainingDatasetSplit(TrainingDataset trainingDataset, String name, float percentage) {
+    this.trainingDataset = trainingDataset;
+    this.name = name;
+    this.percentage = percentage;
+  }
+  
+  public static long getSerialVersionUID() {
+    return serialVersionUID;
+  }
+  
+  public Integer getId() {
+    return id;
+  }
+  
+  public void setId(Integer id) {
+    this.id = id;
+  }
+  
+  public TrainingDataset getTrainingDataset() {
+    return trainingDataset;
+  }
+  
+  public void setTrainingDataset(
+    TrainingDataset trainingDataset) {
+    this.trainingDataset = trainingDataset;
+  }
+  
+  public String getName() {
+    return name;
+  }
+  
+  public void setName(String name) {
+    this.name = name;
+  }
+  
+  public float getPercentage() {
+    return percentage;
+  }
+  
+  public void setPercentage(float percentage) {
+    this.percentage = percentage;
+  }
+  
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    
+    TrainingDatasetSplit that = (TrainingDatasetSplit) o;
+    
+    if (Float.compare(that.percentage, percentage) != 0) {
+      return false;
+    }
+    if (id != null ? !id.equals(that.id) : that.id != null) {
+      return false;
+    }
+    if (trainingDataset != null ? !trainingDataset.equals(that.trainingDataset) : that.trainingDataset != null) {
+      return false;
+    }
+    return name != null ? name.equals(that.name) : that.name == null;
+  }
+  
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (trainingDataset != null ? trainingDataset.hashCode() : 0);
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (percentage != +0.0f ? Float.floatToIntBits(percentage) : 0);
+    return result;
+  }
+}

--- a/hopsworks-persistence/src/main/resources/META-INF/persistence.xml
+++ b/hopsworks-persistence/src/main/resources/META-INF/persistence.xml
@@ -62,6 +62,7 @@
     <class>io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.hopsfs.HopsfsTrainingDataset</class>
     <class>io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.external.ExternalTrainingDataset</class>
     <class>io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.TrainingDataset</class>
+    <class>io.hops.hopsworks.persistence.entity.featurestore.trainingdataset.split.TrainingDatasetSplit</class>
     <class>io.hops.hopsworks.persistence.entity.featurestore.jobs.FeaturestoreJob</class>
     <class>io.hops.hopsworks.persistence.entity.featurestore.statistics.columns.StatisticColumn</class>
     <class>io.hops.hopsworks.persistence.entity.featurestore.statistics.FeaturestoreStatistic</class>


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1678

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
