### PR TITLE
[HOPSWORKS-2018] non admin hops users cannot view spark executors logs

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/auxiliary/hello_world.py
+++ b/hopsworks-IT/src/test/ruby/spec/auxiliary/hello_world.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020, Logical Clocks AB. All rights reserved
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pyspark.sql import SparkSession
+from hops import hdfs
+
+spark = SparkSession.builder.appName("hello_world_app").getOrCreate()
+print("hello world")
+project_path = hdfs.project_path()
+mydf = spark.createDataFrame(["10","11","13"], "string").toDF("age")
+mydf.write.csv(project_path + '/Resources/mycsv2.csv')

--- a/hopsworks-IT/src/test/ruby/spec/helpers/session_helper.rb
+++ b/hopsworks-IT/src/test/ruby/spec/helpers/session_helper.rb
@@ -133,7 +133,7 @@ module SessionHelper
 
   def create_session(email, password)
     raw_create_session(email, password)
-    expect_status(200)
+    expect_status_details(200)
     expect_json(sessionID: ->(value){ expect(value).not_to be_empty})
     @user = get_user_by_mail(email)
   end

--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/YarnUIProxyServlet.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/admin/YarnUIProxyServlet.java
@@ -140,10 +140,13 @@ public class YarnUIProxyServlet extends ProxyServlet {
       return;
     }
     if (!servletRequest.isUserInRole("HOPS_ADMIN")) {
-      if (servletRequest.getRequestURI().contains("proxy/application") || servletRequest.getRequestURI().contains(
-        "app/application") || servletRequest.getRequestURI().contains("appattempt/appattempt") || servletRequest.
-        getRequestURI().contains("container/container") || servletRequest.getRequestURI().contains(
-        "containerlogs/container") || servletRequest.getRequestURI().contains("history/application")) {
+      if (servletRequest.getRequestURI().contains("proxy/application")
+        || servletRequest.getRequestURI().contains("app/application")
+        || servletRequest.getRequestURI().contains("appattempt/appattempt")
+        || servletRequest.getRequestURI().contains("container/container")
+        || servletRequest.getRequestURI().contains("containerlogs/container")
+        || servletRequest.getRequestURI().contains("history/application")
+        || servletRequest.getRequestURI().contains("applications/application")) {
         
         String email = servletRequest.getUserPrincipal().getName();
         Pattern pattern = Pattern.compile("(application_.*?_.\\d*)");


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-2018

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
