### PR TITLE
[HOPSWORKS-2302] Hide python pip search bar as underlying pip search is now deprecated

### DIFF
--- a/hopsworks-web/yo/app/views/python.html
+++ b/hopsworks-web/yo/app/views/python.html
@@ -195,6 +195,8 @@
                         </form>
                       </div>
                     </fieldset>
+
+                    <!-- Hide this functionality for now, reintroduce with https://logicalclocks.atlassian.net/browse/HOPSWORKS-2303
                     <fieldset>
                       <div class="control-group">
                         <div class="row"></div>
@@ -216,8 +218,8 @@
                         </form>
                       </div>
                     </fieldset>
-
                     <div class="col-md-offset-1" ng-show="pythonCtrl.pipResultsMessageShowing">{{pythonCtrl.pipResultsMsg}}</div>
+                  -->
 
                   </div>
 


### PR DESCRIPTION


## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
