### PR TITLE
[HOPSWORKS-2473] dataset read acl list does not get cleared on dataset delete

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/dataset_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/dataset_spec.rb
@@ -394,6 +394,11 @@ describe "On #{ENV['OS']}" do
           delete_dataset(@project, "Logs", datasetType: "?type=DATASET")
           expect_status(204)
         end
+        it "should create-delete-create dataset" do
+          dsname = create_random_dataset(@project, true, false)
+          delete_dataset(@project, dsname)
+          create_dataset_by_name_checked(@project, dsname)
+        end
       end
     end
     describe "#request" do

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/dataset/DatasetController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/dataset/DatasetController.java
@@ -1205,12 +1205,12 @@ public class DatasetController {
       }
       
       if (isDataset) {
-        //remove the group associated with this dataset as it is a toplevel ds
+        //remove the groups associated with this dataset as it is a toplevel ds
         try {
-          hdfsUsersController.deleteDatasetGroup(dataset);
+          hdfsUsersController.deleteDatasetGroups(project, dataset);
         } catch (IOException ex) {
           //FIXME: take an action?
-          LOGGER.log(Level.WARNING, "Error while trying to delete a dataset group", ex);
+          LOGGER.log(Level.WARNING, "Error while trying to delete the dataset groups", ex);
         }
       }
     }

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/HdfsUsersController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/hdfs/HdfsUsersController.java
@@ -218,20 +218,23 @@ public class HdfsUsersController {
   }
 
   /**
-   * Deletes the dataset group from HDFS
+   * Deletes the dataset group and datasetAcl group from HDFS
    * <p>
    * @param dataset
    * @throws java.io.IOException
    */
-  public void deleteDatasetGroup(Dataset dataset) throws IOException {
+  public void deleteDatasetGroups(Project project, Dataset dataset) throws IOException {
     if (dataset == null) {
       throw new IllegalArgumentException("One or more arguments are null.");
     }
     String datasetGroup = getHdfsGroupName(dataset);
+    String datasetAclGroup = getHdfsAclGroupName(project, dataset);
+    
     DistributedFileSystemOps dfso = null;
     try {
       dfso = dfsService.getDfsOps();
       dfso.removeGroup(datasetGroup);
+      dfso.removeGroup(datasetAclGroup);
     } finally {
       dfsService.closeDfsClient(dfso);
     }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://logicalclocks.atlassian.net/browse/HOPSWORKS-2473

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
