### PR TITLE
[HOPSWORKS-2510][2.2] Updating validationType on feature group response contains old value

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/FeaturegroupController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/FeaturegroupController.java
@@ -509,7 +509,7 @@ public class FeaturegroupController {
                     "featuregroup: " + featuregroup.getName()));
     toUpdate.setValidationType(validationType);
     featuregroupFacade.updateFeaturegroupMetadata(toUpdate);
-    return convertFeaturegrouptoDTO(featuregroup, project, user);
+    return convertFeaturegrouptoDTO(toUpdate, project, user);
   }
 
   /**


### PR DESCRIPTION
(cherry picked from commit b2c9801772da9cf3cf41bbb26b15b0cc1be41571)

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
