### PR TITLE
[HOPSWORKS-2522] PyPiLibraryElasticIndexer leaks indices when unable to connect to PyPi

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/provenance/core/ProvenanceCleanerController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/provenance/core/ProvenanceCleanerController.java
@@ -51,7 +51,7 @@ public class ProvenanceCleanerController {
   public Pair<Integer, String> indexCleanupRound(String nextToCheck, Integer limit)
     throws ProvenanceException, ElasticException {
     String indexRegex = "*" + Settings.PROV_FILE_INDEX_SUFFIX;
-    String[] indices = client.mngIndicesGetByRegex(indexRegex);
+    String[] indices = client.mngIndicesGetBySimplifiedRegex(indexRegex);
     
     int cleaned = 0;
     String nextToCheckAux = "";

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/python/updates/LibraryUpdatesMonitor.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/python/updates/LibraryUpdatesMonitor.java
@@ -72,7 +72,7 @@ public class LibraryUpdatesMonitor {
     HsfsLatestVersionAnalyzer hsfsAnalyzer = new HsfsLatestVersionAnalyzer();
     latestVersionAnalyzerMap.put(hsfsAnalyzer.getLibrary(), hsfsAnalyzer);
 
-    String rawInterval = settings.getPyPiIndexerTimerInterval();
+    String rawInterval = settings.getPythonLibraryUpdatesMonitorInterval();
     Long intervalValue = settings.getConfTimeValue(rawInterval);
     TimeUnit intervalTimeunit = settings.getConfTimeTimeUnit(rawInterval);
 

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/Settings.java
@@ -127,6 +127,7 @@ public class Settings implements Serializable {
   private static final String VARIABLE_ADMIN_EMAIL = "admin_email";
   private static final String VARIABLE_PYPI_REST_ENDPOINT = "pypi_rest_endpoint";
   private static final String VARIABLE_PYPI_INDEXER_TIMER_INTERVAL = "pypi_indexer_timer_interval";
+  private static final String VARIABLE_PYPI_INDEXER_TIMER_ENABLED = "pypi_indexer_timer_enabled";
   private static final String VARIABLE_PYPI_SIMPLE_ENDPOINT = "pypi_simple_endpoint";
   private static final String VARIABLE_PYTHON_LIBRARY_UPDATES_MONITOR_INTERVAL =
     "python_library_updates_monitor_interval";
@@ -666,6 +667,7 @@ public class Settings implements Serializable {
       PYPI_INDEXER_TIMER_INTERVAL = setStrVar(VARIABLE_PYPI_INDEXER_TIMER_INTERVAL, PYPI_INDEXER_TIMER_INTERVAL);
       PYTHON_LIBRARY_UPDATES_MONITOR_INTERVAL = setStrVar(VARIABLE_PYTHON_LIBRARY_UPDATES_MONITOR_INTERVAL,
         PYTHON_LIBRARY_UPDATES_MONITOR_INTERVAL);
+      PYPI_INDEXER_TIMER_ENABLED = setBoolVar(VARIABLE_PYPI_INDEXER_TIMER_ENABLED, PYPI_INDEXER_TIMER_ENABLED);
 
       IMMUTABLE_PYTHON_LIBRARY_NAMES = toSetFromCsv(
           setStrVar(VARIABLE_IMMUTABLE_PYTHON_LIBRARY_NAMES, DEFAULT_IMMUTABLE_PYTHON_LIBRARY_NAMES),
@@ -2431,6 +2433,13 @@ public class Settings implements Serializable {
   public synchronized String getPyPiSimpleEndpoint() {
     checkCache();
     return PYPI_SIMPLE_ENDPOINT;
+  }
+
+  private boolean PYPI_INDEXER_TIMER_ENABLED = true;
+
+  public synchronized boolean isPyPiIndexerTimerEnabled() {
+    checkCache();
+    return PYPI_INDEXER_TIMER_ENABLED;
   }
 
   private String PYTHON_LIBRARY_UPDATES_MONITOR_INTERVAL = "1d";


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
