### PR TITLE
[HOPSWORKS-2536] Online FS Avro schema constructor decimals should take precision and scale

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/online/AvroSchemaConstructorController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/featuregroup/online/AvroSchemaConstructorController.java
@@ -81,8 +81,16 @@ public class AvroSchemaConstructorController {
       case TIMESTAMP_TYPE:
         return LogicalTypes.timestampMicros().addToSchema(avroSchema.longType());
       case DECIMAL_TYPE:
-        // is this precision/scale correct?
-        return LogicalTypes.decimal(Type.DECIMAL_TYPE.getMaxPrecision(),Type.DECIMAL_TYPE.getMaximumScale())
+        String precisionScale = hiveType.substring(7);
+        String[] precisionScaleArray;
+        if (precisionScale.startsWith("(") && precisionScale.endsWith(")")) {
+          precisionScale = precisionScale.substring(1, precisionScale.length() - 1);
+          precisionScaleArray = precisionScale.split(",", 2);
+        } else {
+          throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.AVRO_MALFORMED_SCHEMA, Level.FINE, "The " +
+            "provided type is malformed: " + hiveType);
+        }
+        return LogicalTypes.decimal(Integer.parseInt(precisionScaleArray[0]), Integer.parseInt(precisionScaleArray[1]))
           .addToSchema(avroSchema.bytesType());
       default:
         // shouldn't happen

--- a/hopsworks-common/src/test/io/hops/hopsworks/common/featurestore/featuregroup/online/TestAvroSchemaConstructorController.java
+++ b/hopsworks-common/src/test/io/hops/hopsworks/common/featurestore/featuregroup/online/TestAvroSchemaConstructorController.java
@@ -112,9 +112,10 @@ public class TestAvroSchemaConstructorController {
   
   @Test
   public void testToPrimitiveTypeLogicalDecimal() throws Exception {
-    String hiveType = "decimal";
+    String hiveType = "decimal(10,6)";
     Schema result = avroSchemaConstructorController.toAvroPrimitiveType(hiveType);
-    Assert.assertEquals("{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":38,\"scale\":0}", result.toString());
+    Assert.assertEquals("{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":10,\"scale\":6}",
+      result.toString());
   }
   
   @Test


### PR DESCRIPTION
(cherry picked from commit f67496db0ad5711daac582574df88fe87eb6f392)
(cherry picked from commit b86a9da7e72defbafe7ddda64447435e84e6c393)

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
