### PR TITLE
[HOPSWORKS-2582] Spark driver cores is incorrectly set to number of configured executor cores

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/util/SparkConfigurationUtil.java
@@ -343,7 +343,7 @@ public class SparkConfigurationUtil extends ConfigurationUtil {
       new ConfigProperty(
         Settings.SPARK_DRIVER_CORES_ENV,
         HopsUtils.OVERWRITE,
-        Integer.toString(experimentType != null ? 1 : sparkJobConfiguration.getExecutorCores())));
+        Integer.toString(experimentType != null ? 1 : sparkJobConfiguration.getAmVCores())));
     sparkProps.put(Settings.SPARK_EXECUTOR_MEMORY_ENV,
       new ConfigProperty(
         Settings.SPARK_EXECUTOR_MEMORY_ENV,


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
