### PR TITLE
[HOPSWORKS-2614] Training Dataset from Python with default connector fails

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetInputValidation.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/trainingdatasets/TrainingDatasetInputValidation.java
@@ -189,7 +189,7 @@ public class TrainingDatasetInputValidation {
 
   private void validateStorageConnector(FeaturestoreStorageConnectorDTO connectorDTO)
       throws FeaturestoreException {
-    if (connectorDTO == null) {
+    if (connectorDTO == null || connectorDTO.getId() == null) {
       // The storage connector is null, the training dataset will use the default
       // HopsFS training dataset connector controller from the project
       return;


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
