### PR TITLE
[HOPSWORKS-2660] No user feedback when jupyter is not launched due to cpu/memory constraints

### DIFF
--- a/hopsworks-web/yo/app/views/dockerJobConfig.html
+++ b/hopsworks-web/yo/app/views/dockerJobConfig.html
@@ -46,7 +46,7 @@
             <input type="number" class="form-control" id="mem" name="memory" step="1" ng-min="1024" ng-max="newJobCtrl.maxDockerMemory" ng-model="newJobCtrl.runConfig.resourceConfig.memory" required>
             <span class="text-danger" ng-show="(newJobCtrl.dockerJobConfigForm.memory.$dirty) && newJobCtrl.dockerJobConfigForm.memory.$error.number">Must be a number.</span>
             <span class="text-danger" ng-show="(newJobCtrl.dockerJobConfigForm.memory.$dirty) && newJobCtrl.dockerJobConfigForm.memory.$error.max">You can at most allocate {{newJobCtrl.maxDockerMemory}} MB.</span>
-            <span class="text-danger" ng-show="(newJobCtrl.dockerJobConfigForm.memory.$dirty) && newJobCtrl.dockerJobConfigForm.memory.$error.min">It is recommended to allocate at minimum 1024 MB.</span>
+            <span class="text-danger" ng-show="(newJobCtrl.dockerJobConfigForm.memory.$untouched || newJobCtrl.dockerJobConfigForm.memory.$dirty) && newJobCtrl.dockerJobConfigForm.memory.$error.min">It is recommended to allocate at minimum 1024 MB.</span>
         </div>
     </div>
     <div class="form-group" ng-show="newJobCtrl.hasDockerCores">

--- a/hopsworks-web/yo/app/views/jupyter/pythonConfig.html
+++ b/hopsworks-web/yo/app/views/jupyter/pythonConfig.html
@@ -34,7 +34,7 @@
             <input type="number" class="form-control" id="mem" name="dockerMemory" step="1" ng-min="1024" ng-max="jupyterCtrl.maxDockerMemory" ng-model="jupyterCtrl.jupyterSettings.dockerConfig.resourceConfig.memory" required>
             <span class="text-danger" ng-show="(jupyterCtrl.pythonConfigForm.dockerMemory.$dirty) && jupyterCtrl.pythonConfigForm.dockerMemory.$error.number">Must be a number.</span>
             <span class="text-danger" ng-show="(jupyterCtrl.pythonConfigForm.dockerMemory.$dirty) && jupyterCtrl.pythonConfigForm.dockerMemory.$error.max">You can at most allocate {{jupyterCtrl.maxDockerMemory}} MB.</span>
-            <span class="text-danger" ng-show="(jupyterCtrl.pythonConfigForm.dockerMemory.$dirty) && jupyterCtrl.pythonConfigForm.dockerMemory.$error.min">It is recommended to allocate at minimum 1024 MB.</span>
+            <span class="text-danger" ng-show="(jupyterCtrl.pythonConfigForm.dockerMemory.$untouched || jupyterCtrl.pythonConfigForm.dockerMemory.$dirty) && jupyterCtrl.pythonConfigForm.dockerMemory.$error.min">It is recommended to allocate at minimum 1024 MB.</span>
         </div>
     </div>
     <div class="form-group" ng-show="jupyterCtrl.hasDockerCores">

--- a/hopsworks-web/yo/app/views/pythonJobConfig.html
+++ b/hopsworks-web/yo/app/views/pythonJobConfig.html
@@ -22,7 +22,7 @@
             <input type="number" class="form-control" id="mem" name="memory" step="1" ng-min="1024" ng-max="newJobCtrl.maxDockerMemory" ng-model="newJobCtrl.runConfig.resourceConfig.memory" required>
             <span class="text-danger" ng-show="(newJobCtrl.pythonJobConfigForm.memory.$dirty) && newJobCtrl.pythonJobConfigForm.memory.$error.number">Must be a number.</span>
             <span class="text-danger" ng-show="(newJobCtrl.pythonJobConfigForm.memory.$dirty) && newJobCtrl.pythonJobConfigForm.memory.$error.max">You can at most allocate {{newJobCtrl.maxDockerMemory}} MB.</span>
-            <span class="text-danger" ng-show="(newJobCtrl.pythonJobConfigForm.memory.$dirty) && newJobCtrl.pythonJobConfigForm.memory.$error.min">It is recommended to allocate at minimum 1024 MB.</span>
+            <span class="text-danger" ng-show="(newJobCtrl.pythonJobConfigForm.memory.$untouched || newJobCtrl.pythonJobConfigForm.memory.$dirty) && newJobCtrl.pythonJobConfigForm.memory.$error.min">It is recommended to allocate at minimum 1024 MB.</span>
         </div>
     </div>
     <div class="form-group" ng-show="newJobCtrl.hasDockerCores">


### PR DESCRIPTION
[HOPSWORKS-2660] No user feedback when jupyter is not launched due to cpu/memory constraints

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
JIRA https://logicalclocks.atlassian.net/browse/HOPSWORKS-2660

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement


* **What is the new behavior (if this is a feature change)?**
* Improvement: The warning message for memory less than minimum for on Jupyter and python job UI is triggered on page load in addition to field edit.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:


[HOPSWORKS-2660]: https://logicalclocks.atlassian.net/browse/HOPSWORKS-2660