### PR TITLE
[HOPSWORKS-2899][append] feature group data preview should default to online feature store

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/factories/online_fg_2.rb
+++ b/hopsworks-IT/src/test/ruby/spec/factories/online_fg_2.rb
@@ -1,0 +1,20 @@
+=begin
+ This file is part of Hopsworks
+ Copyright (C) 2022, Logical Clocks AB. All rights reserved
+
+ Hopsworks is free software: you can redistribute it and/or modify it under the terms of
+ the GNU Affero General Public License as published by the Free Software Foundation,
+ either version 3 of the License, or (at your option) any later version.
+
+ Hopsworks is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.  See the GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License along with this program.
+ If not, see <https://www.gnu.org/licenses/>.
+=end
+class OnlineFg1 < ActiveRecord::Base
+  def self.table_name
+    "online_fs1.online_fg_1"
+  end
+end

--- a/hopsworks-IT/src/test/ruby/spec/featuregroup_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/featuregroup_spec.rb
@@ -2189,7 +2189,7 @@ describe "On #{ENV['OS']}" do
       end
 
       it "should fetch the online feature data if the fg is online enabled and storage not specified" do
-        project = create_project_by_name_existing_user("online_fs")
+        project = create_project_by_name_existing_user("online_fs1")
         featurestore_id = get_featurestore_id(project.id)
         json_result, _ = create_cached_featuregroup(project.id, featurestore_id, featuregroup_name: 'online_fg', online:true)
         parsed_json = JSON.parse(json_result)
@@ -2197,8 +2197,8 @@ describe "On #{ENV['OS']}" do
         featuregroup_id = parsed_json["id"]
 
         # add sample ros
-        OnlineFg.create(testfeature: 1).save
-        OnlineFg.create(testfeature: 2).save
+        OnlineFg1.create(testfeature: 1).save
+        OnlineFg1.create(testfeature: 2).save
 
         get "#{ENV['HOPSWORKS_API']}/project/#{project.id}/featurestores/#{featurestore_id}/featuregroups/#{featuregroup_id}/preview?&limit=1"
         expect_status(200)


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
