### PR TITLE
[HOPSWORKS-2935] jupyter_spec insufficient spark memory test should set python kernel to false

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/jupyter_spec.rb
+++ b/hopsworks-IT/src/test/ruby/spec/jupyter_spec.rb
@@ -179,6 +179,7 @@ describe "On #{ENV['OS']}" do
         settings = json_body
         settings[:distributionStrategy] = ""
         settings[:shutdownLevel] = shutdownLevel
+        settings[:pythonKernel] = false
         settings[:jobConfig][:"spark.executor.memory"] = 1023
         json_result = post "#{ENV['HOPSWORKS_API']}/project/#{@project[:id]}/jupyter/start", JSON(settings)
         expect_status_details(400)


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
