### PR TITLE
[HOPSWORKS-3077] Conversion of Jupyter Notebook should consider Job Type and Serving

### DIFF
--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/spark/SparkController.java
@@ -146,7 +146,7 @@ public class SparkController {
       String pyAppPath = HopsUtils.prepJupyterNotebookConversion(exec, username, dfs);
       sparkConfig.setAppPath(pyAppPath);
       jupyterController.convertIPythonNotebook(username, appPath, job.getProject(), pyAppPath,
-          jupyterController.getNotebookConversionType(appPath, user, job.getProject()));
+        JupyterController.NotebookConversion.PY);
     }
 
     submitter.startExecution(sparkjob, args);


### PR DESCRIPTION
* [HOPSWORKS-3077] for jobs, notebook conversion should consider job type
* [HOPSWORKS-3077] predictor and transformer scripts should always be converted to pure python

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**
https://hopsworks.atlassian.net/browse/HOPSWORKS-3077

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
