### PR TITLE
[HWORKS-364] Update flatbuffers dependency in Hive to address CVE-2020-36632

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <googlecode-json-simple.version>1.1.1</googlecode-json-simple.version>
     <handy-uri-templates.version>2.1.8</handy-uri-templates.version>
     <hive.version>3.0.0.13-SNAPSHOT</hive.version>
-    <hops.version>3.2.0.8-RC0</hops.version>
+    <hops.version>3.2.0.9-SNAPSHOT</hops.version>
     <jackson-core-asl.version>1.9.13</jackson-core-asl.version>
     <jackson.version>2.12.4</jackson.version>
     <jackson-datatype-jsr310.version>2.12.1</jackson-datatype-jsr310.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <google-zxing-javase.version>3.0.0</google-zxing-javase.version>
     <googlecode-json-simple.version>1.1.1</googlecode-json-simple.version>
     <handy-uri-templates.version>2.1.8</handy-uri-templates.version>
-    <hive.version>3.0.0.11</hive.version>
+    <hive.version>3.0.0.13-SNAPSHOT</hive.version>
     <hops.version>3.2.0.8-RC0</hops.version>
     <jackson-core-asl.version>1.9.13</jackson-core-asl.version>
     <jackson.version>2.12.4</jackson.version>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -201,4 +201,14 @@
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@1\.27$</packageUrl>
     <cve>CVE-2022-1471</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[file name: flatbuffers-1.2.0-3f79e055.jar]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.vlkan/flatbuffers@.*$</packageUrl>
+    <cve>CVE-2020-36632</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[file name: flatbuffers-java-1.9.0.jar]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.google\.flatbuffers/flatbuffers-java@.*$</packageUrl>
+    <cve>CVE-2020-36632</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
