### PR TITLE
[HWORKS-390] app_id field in execution table is too short

### DIFF
--- a/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/jobs/history/Execution.java
+++ b/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/jobs/history/Execution.java
@@ -185,7 +185,7 @@ public class Execution implements Serializable {
   @Column(name = "stderr_path")
   private String stderrPath;
 
-  @Size(max = 30)
+  @Size(max = 45)
   @Column(name = "app_id")
   private String appId;
 

--- a/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/maggy/MaggyDriver.java
+++ b/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/maggy/MaggyDriver.java
@@ -55,7 +55,7 @@ public class MaggyDriver implements Serializable {
   @Basic(optional = false)
   @NotNull
   @Size(min = 1,
-      max = 30)
+      max = 45)
   @Column(name = "app_id")
   private String appId;
   @Basic(optional = false)


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
