### PR TITLE
[FSTORE-697] handle timezones in validation report timestamp (#1285)

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/datavalidationv2/results/ValidationResultBuilder.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/datavalidationv2/results/ValidationResultBuilder.java
@@ -30,6 +30,8 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.ws.rs.core.UriInfo;
+
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.text.SimpleDateFormat;
 import org.json.JSONObject;
@@ -72,7 +74,9 @@ public class ValidationResultBuilder {
       metaJson.put("ingestionResult", validationResult.getIngestionResult());
       // Same validation string as in validationController to parse time provided by GE
       String formatDateString = "yyyy-MM-dd'T'hh:mm:ss.SSSSSSX";
-      String validationTime = new SimpleDateFormat(formatDateString).format(validationResult.getValidationTime());
+      SimpleDateFormat isoFormat = new SimpleDateFormat(formatDateString);
+      isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      String validationTime = isoFormat.format(validationResult.getValidationTime());
       metaJson.put("validationTime", validationTime);
       dto.setMeta(metaJson.toString());
       dto.setValidationTime(validationTime);


### PR DESCRIPTION
* Forcing UTC to avoid timezone issue

* Fix timezone issue in validation report controller

* Fix time formatting of json report written to disk

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
