### PR TITLE
[FSTORE-697] handle timezones in validation report timestamp (#1285)

### DIFF
--- a/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/datavalidationv2/results/ValidationResultBuilder.java
+++ b/hopsworks-api/src/main/java/io/hops/hopsworks/api/featurestore/datavalidationv2/results/ValidationResultBuilder.java
@@ -29,6 +29,8 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.ws.rs.core.UriInfo;
+
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.text.SimpleDateFormat;
 import org.json.JSONObject;
@@ -70,7 +72,9 @@ public class ValidationResultBuilder {
       metaJson.put("ingestionResult", validationResult.getIngestionResult());
       // Same validation string as in validationController to parse time provided by GE
       String formatDateString = "yyyy-MM-dd'T'hh:mm:ss.SSSSSSX";
-      String validationTime = new SimpleDateFormat(formatDateString).format(validationResult.getValidationTime());
+      SimpleDateFormat isoFormat = new SimpleDateFormat(formatDateString);
+      isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      String validationTime = isoFormat.format(validationResult.getValidationTime());
       metaJson.put("validationTime", validationTime);
       dto.setMeta(metaJson.toString());
       dto.setValidationTime(validationTime);

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/datavalidationv2/reports/ValidationReportController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/datavalidationv2/reports/ValidationReportController.java
@@ -68,6 +68,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -263,7 +264,9 @@ public class ValidationReportController {
       JSONObject reportMeta = new JSONObject(reportDTO.getMeta());
       String validationTimeString = reportMeta.getString("validation_time");
       String formatDateString = "yyyyMMdd'T'HHmmss.SSS";
-      validationTime = new SimpleDateFormat(formatDateString).parse(
+      SimpleDateFormat isoFormat = new SimpleDateFormat(formatDateString);
+      isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      validationTime = isoFormat.parse(
         validationTimeString.substring(0, validationTimeString.length() - 4));
     } catch (JSONException | ParseException exception) {
       validationTime = new Date();
@@ -311,6 +314,7 @@ public class ValidationReportController {
         udfso.mkdir(reportDirPath.toString());
       }
       SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HHmmss");
+      formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
       String fileName = String.format("validation_report_%s.json", formatter.format(validationTime));
       Path reportPath = new Path(reportDirPath, fileName);
       if (udfso.exists(reportPath)) {
@@ -318,9 +322,8 @@ public class ValidationReportController {
           Level.SEVERE, String.format("Validation report with file name %s already exists.", fileName));
       }
       udfso.create(reportPath, reportJSON.toString());
-      Inode inode = inodeController.getInodeAtPath(reportPath.toString());
-
-      return inode;
+      
+      return inodeController.getInodeAtPath(reportPath.toString());
     } catch (DatasetException | HopsSecurityException | IOException e) {
       throw new FeaturestoreException(RESTCodes.FeaturestoreErrorCode.ERROR_SAVING_ON_DISK_VALIDATION_REPORT,
         Level.WARNING, e.getMessage());


### PR DESCRIPTION
* Forcing UTC to avoid timezone issue

* Fix timezone issue in validation report controller

* Fix time formatting of json report written to disk

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
