### PR TITLE
[HWORKS-887] Fix revoke Kubernetes certificate API

### DIFF
--- a/hopsworks-ca/src/main/java/io/hops/hopsworks/ca/api/certificates/HostCertsResource.java
+++ b/hopsworks-ca/src/main/java/io/hops/hopsworks/ca/api/certificates/HostCertsResource.java
@@ -140,7 +140,7 @@ public class HostCertsResource {
 
     final List<X500Name> subjectsToRevoke = new ArrayList<>();
     try {
-      if (exact == null || !exact) {
+      if (!Boolean.TRUE.equals(exact)) {
         X500Name certificateName = pkiUtils.parseCertificateSubjectName(certId, HOST);
         List<String> subjects = pkiUtils.findAllValidSubjectsWithPartialMatch(certificateName.toString());
         subjects.forEach(s -> subjectsToRevoke.add(new X500Name(s)));


### PR DESCRIPTION
[HWORKS-887] Issue Strimzi operator CA certificate

* Update hopsworks-ca/src/main/java/io/hops/hopsworks/ca/api/certificates/KubeCertsResource.java



* [HWORKS-887] Update check based on suggestion

* [HWORKS-887] Fix tests for BasicConstrains

---------

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [x] Adds tests for the submitted changes (for bug fixes & features)
- [x] Passes the tests
- [x] HOPSWORKS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:


[HWORKS-887]: https://hopsworks.atlassian.net/browse/HWORKS-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-887]: https://hopsworks.atlassian.net/browse/HWORKS-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-887]: https://hopsworks.atlassian.net/browse/HWORKS-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ