### PR TITLE
[FSTORE-1096] store password as secrets for JDBC connector (#1717)

### DIFF
--- a/hopsworks-IT/src/test/ruby/spec/helpers/storage_connector_helper.rb
+++ b/hopsworks-IT/src/test/ruby/spec/helpers/storage_connector_helper.rb
@@ -82,7 +82,7 @@ module StorageConnectorHelper
     [json_result, connector_name]
   end
 
-  def create_jdbc_connector(project_id, featurestore_id, connectionString: "jdbc://test")
+  def create_jdbc_connector(project_id, featurestore_id, connectionString: "jdbc://test", arguments:[{name: "test1", value: "test2"}])
     type = "featurestoreJdbcConnectorDTO"
     storageConnectorType = "JDBC"
     create_jdbc_connector_endpoint = "#{ENV['HOPSWORKS_API']}/project/#{project_id}/featurestores/#{featurestore_id}/storageconnectors"
@@ -93,14 +93,14 @@ module StorageConnectorHelper
         type: type,
         storageConnectorType: storageConnectorType,
         connectionString: connectionString,
-        arguments: [{name: "test1", value: "test2"}]
+        arguments: arguments
     }
     json_data = json_data.to_json
     json_result = post create_jdbc_connector_endpoint, json_data
     return json_result, jdbc_connector_name
   end
 
-  def update_jdbc_connector(project_id, featurestore_id, connector_name, connectionString: "jdbc://test")
+  def update_jdbc_connector(project_id, featurestore_id, connector_name, connectionString: "jdbc://test", arguments:[{name: "test1", value: "test2"}])
     type = "featurestoreJdbcConnectorDTO"
     storageConnectorType = "JDBC"
     update_jdbc_connector_endpoint = "#{ENV['HOPSWORKS_API']}/project/#{project_id}/featurestores/#{featurestore_id}/storageconnectors/#{connector_name}"
@@ -110,7 +110,7 @@ module StorageConnectorHelper
         type: type,
         storageConnectorType: storageConnectorType,
         connectionString: connectionString,
-        arguments: [{name: "test1", value: "test2"}]
+        arguments: arguments
     }
     put update_jdbc_connector_endpoint, json_data.to_json
   end

--- a/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/storageconnectors/FeaturestoreStorageConnectorController.java
+++ b/hopsworks-common/src/main/java/io/hops/hopsworks/common/featurestore/storageconnectors/FeaturestoreStorageConnectorController.java
@@ -277,7 +277,7 @@ public class FeaturestoreStorageConnectorController {
       case JDBC:
         featurestoreConnector.setConnectorType(FeaturestoreConnectorType.JDBC);
         featurestoreConnector.setJdbcConnector(jdbcConnectorController.createFeaturestoreJdbcConnector(
-            (FeaturestoreJdbcConnectorDTO) featurestoreStorageConnectorDTO));
+          user, featurestore, (FeaturestoreJdbcConnectorDTO) featurestoreStorageConnectorDTO));
         break;
       case REDSHIFT:
         featurestoreConnector.setConnectorType(FeaturestoreConnectorType.REDSHIFT);
@@ -365,7 +365,8 @@ public class FeaturestoreStorageConnectorController {
         break;
       case JDBC:
         featurestoreConnector.setJdbcConnector(jdbcConnectorController.updateFeaturestoreJdbcConnector(
-            (FeaturestoreJdbcConnectorDTO) featurestoreStorageConnectorDTO, featurestoreConnector.getJdbcConnector()));
+          user, featurestore, (FeaturestoreJdbcConnectorDTO) featurestoreStorageConnectorDTO,
+          featurestoreConnector.getJdbcConnector()));
         break;
       case REDSHIFT:
         featurestoreConnector.setRedshiftConnector(redshiftConnectorController.updateFeaturestoreRedshiftConnector(

--- a/hopsworks-common/src/test/io/hops/hopsworks/common/featurestore/storageconnectors/TestStorageConnectorUtil.java
+++ b/hopsworks-common/src/test/io/hops/hopsworks/common/featurestore/storageconnectors/TestStorageConnectorUtil.java
@@ -16,6 +16,7 @@
 
 package io.hops.hopsworks.common.featurestore.storageconnectors;
 
+import io.hops.hopsworks.common.featurestore.FeaturestoreConstants;
 import io.hops.hopsworks.common.featurestore.OptionDTO;
 import io.hops.hopsworks.common.util.Settings;
 import io.hops.hopsworks.persistence.entity.featurestore.storageconnector.FeaturestoreConnectorType;
@@ -27,6 +28,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -115,7 +117,7 @@ public class TestStorageConnectorUtil {
     // as well as their corresponding tests:
     // StorageConnectorUtil.getEnabledStorageConnectorTypes() -> testGetEnabledStorageConnectorTypes
     // StorageConnectorUtil.isStorageConnectorTypeEnabled() -> testIsStorageConnectorTypeEnabled
-    Assert.assertEquals(FeaturestoreConnectorType.values().length, 10);
+    Assert.assertEquals(10, FeaturestoreConnectorType.values().length);
   }
 
   @Test
@@ -160,5 +162,51 @@ public class TestStorageConnectorUtil {
     Assert.assertFalse(storageConnectorUtil.isStorageConnectorTypeEnabled(FeaturestoreConnectorType.KAFKA));
     Assert.assertFalse(storageConnectorUtil.isStorageConnectorTypeEnabled(FeaturestoreConnectorType.GCS));
     Assert.assertFalse(storageConnectorUtil.isStorageConnectorTypeEnabled(FeaturestoreConnectorType.BIGQUERY));
+  }
+  
+  @Test
+  public void test_replaceToPlainText() {
+    // Test the method replaceToPlainText with connectionString
+    final String  PASSWORD_VALUE = "password123";
+    String connectionString = "jdbc:mysql://localhost:3306/hopsworks?user=root&password="
+      + FeaturestoreConstants.ONLINE_FEATURE_STORE_CONNECTOR_PASSWORD_TEMPLATE;
+    String password = "password123";
+    String expectedConnectionString = "jdbc:mysql://localhost:3306/hopsworks?user=root&password=" + PASSWORD_VALUE;
+    String actualConnectionString = storageConnectorUtil.replaceToPlainText(connectionString, password);
+    Assert.assertEquals(expectedConnectionString, actualConnectionString);
+    
+    // Test the method replaceToPlainText with arguments
+    List<OptionDTO> arguments = Collections.singletonList(new OptionDTO("password",
+      FeaturestoreConstants.ONLINE_FEATURE_STORE_CONNECTOR_PASSWORD_TEMPLATE));
+    List<OptionDTO> expectedArguments = Collections.singletonList(new OptionDTO("password", PASSWORD_VALUE));
+    List<OptionDTO> actualArguments = storageConnectorUtil.replaceToPlainText(arguments, password);
+    Assert.assertEquals(expectedArguments.get(0).getValue(), actualArguments.get(0).getValue());
+  }
+  
+  @Test
+  public void test_replaceToPasswordTemplate() {
+    // Test the method replaceToPasswordTemplate with connectionString
+    final String  PASSWORD_VALUE = "password123";
+    String connectionString = "jdbc:mysql://localhost:3306/hopsworks?user=root&password=" + PASSWORD_VALUE;
+    String expectedConnectionString = "jdbc:mysql://localhost:3306/hopsworks?user=root&password="
+      + FeaturestoreConstants.ONLINE_FEATURE_STORE_CONNECTOR_PASSWORD_TEMPLATE;
+    String actualConnectionString = storageConnectorUtil.replaceToPasswordTemplate(connectionString, PASSWORD_VALUE);
+    Assert.assertEquals(expectedConnectionString, actualConnectionString);
+    
+    // Test the method replaceToPasswordTemplate with arguments
+    List<OptionDTO> arguments = Collections.singletonList(new OptionDTO("password", PASSWORD_VALUE));
+    String actualArguments = storageConnectorUtil.replaceToPasswordTemplate(arguments);
+    String expectedArguments = storageConnectorUtil.fromOptions(Collections.singletonList(
+      new OptionDTO("password", FeaturestoreConstants.ONLINE_FEATURE_STORE_CONNECTOR_PASSWORD_TEMPLATE)));
+    Assert.assertEquals(expectedArguments, actualArguments);
+  }
+  
+  @Test
+  public void test_fetchPasswordFromUrl() {
+    // Test the method fetchPassword with connectionString
+    final String PASSWORD_VALUE = "password987";
+    String connectionString = "jdbc:mysql://localhost:3306/hopsworks?user=root&password=" + PASSWORD_VALUE;
+    String actualPassword = storageConnectorUtil.fetchPasswordFromJdbcUrl(connectionString);
+    Assert.assertEquals(PASSWORD_VALUE, actualPassword);
   }
 }

--- a/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/featurestore/storageconnector/jdbc/FeaturestoreJdbcConnector.java
+++ b/hopsworks-persistence/src/main/java/io/hops/hopsworks/persistence/entity/featurestore/storageconnector/jdbc/FeaturestoreJdbcConnector.java
@@ -17,13 +17,18 @@
 package io.hops.hopsworks.persistence.entity.featurestore.storageconnector.jdbc;
 
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlRootElement;
+import io.hops.hopsworks.persistence.entity.user.security.secrets.Secret;
 import java.io.Serializable;
 
 /**
@@ -45,6 +50,10 @@ public class FeaturestoreJdbcConnector implements Serializable {
   private String connectionString;
   @Column(name = "arguments")
   private String arguments;
+  @JoinColumns({ @JoinColumn(name = "secret_uid", referencedColumnName = "uid"),
+      @JoinColumn(name = "secret_name", referencedColumnName = "secret_name") })
+  @ManyToOne(cascade = CascadeType.ALL)
+  private Secret passwordSecret;
 
   public static long getSerialVersionUID() {
     return serialVersionUID;
@@ -72,6 +81,14 @@ public class FeaturestoreJdbcConnector implements Serializable {
   
   public void setArguments(String arguments) {
     this.arguments = arguments;
+  }
+
+  public Secret getPasswordSecret() {
+    return passwordSecret;
+  }
+
+  public void setPasswordSecret(Secret encryptionSecret) {
+    this.passwordSecret = encryptionSecret;
   }
 
   @Override


### PR DESCRIPTION
supporting storing password in jdbc connector as secret (cherry-pick)

## Make sure there is no duplicate PR for this issue

* **Please check if the PR meets the following requirements**
- [ ] Adds tests for the submitted changes (for bug fixes & features)
- [ ] Passes the tests
- [ ] HOPSWORKS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit


* **Post a link to the associated JIRA issue**


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
